### PR TITLE
Fix: Add mounted check after async gap in VideoCallScreen PiP flow

### DIFF
--- a/lib/features/socials/view/screens/video_call_screen.dart
+++ b/lib/features/socials/view/screens/video_call_screen.dart
@@ -317,6 +317,12 @@ class _VideoCallScreenState extends ConsumerState<VideoCallScreen> {
       final hostName = widget.hostName;
       final isHost = widget.isHost;
 
+      // Bail out safely if engine initialization failed.
+      if (_engine == null) {
+        _isNavigatingAway = false;
+        return;
+      }
+
       pipOverlay.showPipOverlay(
         context: context,
         engine: _engine!,
@@ -366,10 +372,12 @@ class _VideoCallScreenState extends ConsumerState<VideoCallScreen> {
       // Small delay to ensure overlay is shown
       await Future.delayed(const Duration(milliseconds: 100));
 
-      // Navigate back - call continues in floating overlay
-      if (mounted) {
-        Navigator.pop(context);
+      if (!mounted) {
+        return;
       }
+
+      // Navigate back - call continues in floating overlay
+      Navigator.pop(context);
     } catch (e) {
       debugPrint('[VideoCallScreen] Error handling back button: $e');
       _isNavigatingAway = false;


### PR DESCRIPTION
## Summary
Fixes unsafe async operations in VideoCallScreen PiP flow that could cause crashes.

## Changes
- Guard `_engine` force-unwrap with null check before `showPipOverlay()`
- Add `mounted` check immediately after `Future.delayed()` before `Navigator.pop()`
- Prevents crash if engine fails to initialize or widget is disposed during async delay

## Testing
- [ ] Code compiles without errors
- [ ] `flutter analyze` passes
- [ ] No force-unwrap of `_engine` without null guard
- [ ] `mounted` checked after every await before Navigator/setState

Closes #36