### PR TITLE
fix: dispose TextEditingController in custom amount dialog (closes #33)

### DIFF
--- a/lib/features/global_mirror/view/screens/gift_screen.dart
+++ b/lib/features/global_mirror/view/screens/gift_screen.dart
@@ -288,7 +288,8 @@ class _GiftScreenState extends ConsumerState<GiftScreen> {
     final controller = TextEditingController(
       text: _selectedAmount.toStringAsFixed(0),
     );
-    showDialog(
+
+    showDialog<void>(
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Custom Amount'),
@@ -309,16 +310,20 @@ class _GiftScreenState extends ConsumerState<GiftScreen> {
           FilledButton(
             onPressed: () {
               final value = double.tryParse(controller.text) ?? 1.0;
-              setState(() {
-                _selectedAmount = value.clamp(1.0, 100.0);
-              });
+              if (mounted) {
+                setState(() {
+                  _selectedAmount = value.clamp(1.0, 100.0);
+                });
+              }
               Navigator.pop(ctx);
             },
             child: const Text('Set'),
           ),
         ],
       ),
-    );
+    ).whenComplete(controller.dispose);
+    // .whenComplete guarantees dispose() is called for every exit path:
+    // Cancel button, Set button, tap-outside-to-dismiss, and back-button.
   }
 
   Widget _buildEmptyState(ThemeData theme) {


### PR DESCRIPTION
Closes #33

## Bug
Every time the user opened the custom ECHO amount dialog, a `TextEditingController` was created but never disposed, leaking memory on every dialog open.

## Fix
Chained `.whenComplete(controller.dispose)` on the `showDialog` future. This single call covers all exit paths:
- Cancel button
- Set button
- Tap-outside-to-dismiss
- Back button

Also added a `mounted` guard around `setState()` in the Set button handler to prevent calling setState on an unmounted widget.

## Files changed
- `lib/features/global_mirror/view/screens/gift_screen.dart`