### PR TITLE
Added PR guard to warn when PRs are too large to review

### DIFF
--- a/.github/workflows/pr_guard.yml
+++ b/.github/workflows/pr_guard.yml
@@ -1,0 +1,31 @@
+name: PR Guard
+
+on:
+  pull_request:
+    branches: [main, development]
+
+jobs:
+  size-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR size
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const additions = pr.additions;
+            const deletions = pr.deletions;
+            const total = additions + deletions;
+
+            if (total > 600) {
+              core.warning(
+                `This PR changes ${total} lines (+${additions}/-${deletions}). ` +
+                "Consider splitting it into smaller PRs for easier review."
+              );
+            }
+            if (total > 1000) {
+              core.setFailed(
+                `PR is too large (${total} lines changed). ` +
+                "Please split into smaller focused PRs."
+              );
+            }


### PR DESCRIPTION
closes #65 

 Summary
This PR introduces an automated **PR size guard** to help maintain review quality and keep the merge cycle fast and predictable. Several past PRs bundled unrelated changes (for example, PR #43 included server files pulled in from a development merge), making them harder to review and more prone to bugs. This workflow provides early feedback to contributors before review begins.

 Behavior
- Contributors receive an early warning when a PR becomes too large.
- PRs exceeding 1000 changed lines will fail the check, though maintainers can still override manually.
- Existing PRs were used as a baseline to calibrate thresholds.

 Files Added
- `.github/workflows/pr_guard.yml`

Keeping PRs small and focused:
- Improves review speed  
- Reduces merge conflicts  
- Lowers the risk of regressions  
- Encourages better development hygiene  

