### PR TITLE
fix(backend): resolve lint warnings and naming conventions

### DIFF
--- a/backend/stellar/stellar_service.dart
+++ b/backend/stellar/stellar_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+
 import 'package:http/http.dart' as http;
 import 'package:stellar_flutter_sdk/stellar_flutter_sdk.dart';
 import 'stellar_config.dart';
@@ -21,13 +22,13 @@ class StellarService {
   /// Returns the [KeyPair] containing both public and secret keys.
   static Future<KeyPair> createWallet() async {
     final keypair = KeyPair.random();
-    await _fundViafriendbot(keypair.accountId);
+    await _fundViaFriendbot(keypair.accountId);
     debugPrint('[StellarService] Created wallet: ${keypair.accountId}');
     return keypair;
   }
 
   /// Funds a testnet account with XLM via Stellar Friendbot.
-  static Future<void> _fundViafriendbot(String publicKey) async {
+  static Future<void> _fundViaFriendbot(String publicKey) async {
     final url = '${StellarConfig.friendbotUrl}?addr=$publicKey';
     final response = await http.get(Uri.parse(url));
     if (response.statusCode != 200) {


### PR DESCRIPTION
# Tittle: fix(backend): resolve lint warnings and naming conventions

## Description
This PR resolves issue #9 by ensuring the `backend/` folder is fully lint-clean and follows Dart naming conventions.

## Changes Made
- Renamed `_fundViafriendbot` to [_fundViaFriendbot](cci:1://file:///c:/Trabajos%20Progra/GRANDFOX/Echo-Mirror-Butler-/backend/stellar/stellar_service.dart:29:2-37:3) in [stellar_service.dart](cci:7://file:///c:/Trabajos%20Progra/GRANDFOX/Echo-Mirror-Butler-/backend/stellar/stellar_service.dart:0:0-0:0) to follow camelCase conventions.
- Verified and fixed all linting warnings in the `backend/` directory.
- Formatted all files in `backend/` using `dart format`.

## Acceptance Criteria Verification
- [x] `flutter analyze backend/` outputs: **No issues found!**
- [x] `dart format --set-exit-if-changed backend/` exits with code 0.

## Evidence
<img width="723" height="169" alt="image" src="https://github.com/user-attachments/assets/00f8726b-0fd4-45f5-b2bc-4c69d46daca1" />

## Closes
Closes #9