### PR TITLE
ci: add secret scanning guard with gitleaks (#62)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+  paths = [
+    '''echomirror_server/echomirror_server_server/.env.example''',
+    '''backend/stellar/stellar_config.dart''',
+  ]


### PR DESCRIPTION
PR #62 CI: Add secret scanning guard to block accidental credential commits
## Description
This pull request introduces an automated secret scanning guard using Gitleaks to the CI pipeline. This ensures that accidental credential commits (such as the previous incident with Agora credentials) are blocked before they can be merged.

### Changes Made
- **GitHub Workflow**: Added a new `.github/workflows/secret-scan.yml` workflow that executes Gitleaks on all pull requests and pushes targeting the `main` and `development` branches.
- **Config Allowlist**: Added a `.gitleaks.toml` configuration file to the repository root to ensure that known safe files (like `.env.example` and `stellar_config.dart` containing placeholder values) are explicitly allowlisted, preventing false positives.

### Acceptance Criteria Covered
- [x] Gitleaks runs on every PR and push to `main` / `development`.
- [x] CI fails if a real secret pattern is detected.
- [x] `.gitleaks.toml` allowlist prevents false positives on known safe files.
- [x] Existing codebase passes the scan cleanly.

Closes #62
