### PR TITLE
feat(realtime): notify recipients of gifts during live calls

### DIFF
--- a/lib/core/services/gift_notification_service.dart
+++ b/lib/core/services/gift_notification_service.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../../features/global_mirror/data/models/gift_transaction_model.dart';
+import 'supabase_client_service.dart';
+
+typedef GiftRowsStreamFactory =
+    Stream<List<Map<String, dynamic>>> Function(String userId);
+
+class GiftNotificationService {
+  GiftNotificationService({
+    SupabaseClient? supabaseClient,
+    GiftRowsStreamFactory? streamFactory,
+  }) : _supabase = supabaseClient ?? SupabaseClientService.instance.client,
+       _streamFactory = streamFactory;
+
+  final SupabaseClient _supabase;
+  final GiftRowsStreamFactory? _streamFactory;
+
+  StreamSubscription<List<Map<String, dynamic>>>? _subscription;
+  final Set<int> _seenTransactionIds = <int>{};
+  bool _primed = false;
+
+  void startListening(
+    String userId,
+    void Function(GiftTransactionModel gift) onGift,
+  ) {
+    stopListening();
+    _primed = false;
+    _seenTransactionIds.clear();
+
+    final stream =
+        _streamFactory?.call(userId) ??
+        _supabase
+            .from('gift_transactions')
+            .stream(primaryKey: ['id'])
+            .eq('recipient_user_id', userId);
+
+    _subscription = stream.listen((rows) {
+      final transactions = rows
+          .map((row) => GiftTransactionModel.fromJson(row))
+          .toList();
+
+      if (!_primed) {
+        for (final transaction in transactions) {
+          _seenTransactionIds.add(transaction.id);
+        }
+        _primed = true;
+        return;
+      }
+
+      for (final transaction in transactions) {
+        if (_seenTransactionIds.add(transaction.id)) {
+          onGift(transaction);
+        }
+      }
+    }, onError: (error, stackTrace) {
+      debugPrint('[GiftNotificationService] Realtime stream error: $error');
+    });
+  }
+
+  void stopListening() {
+    _subscription?.cancel();
+    _subscription = null;
+    _seenTransactionIds.clear();
+    _primed = false;
+  }
+}

--- a/lib/features/global_mirror/data/models/gift_transaction_model.dart
+++ b/lib/features/global_mirror/data/models/gift_transaction_model.dart
@@ -21,4 +21,36 @@ class GiftTransactionModel {
   final String? message;
 
   bool get isCompleted => status == 'completed';
+
+  factory GiftTransactionModel.fromJson(Map<String, dynamic> json) {
+    int parseInt(dynamic value) {
+      if (value is int) return value;
+      if (value is num) return value.toInt();
+      return int.tryParse(value?.toString() ?? '') ?? 0;
+    }
+
+    double parseDouble(dynamic value) {
+      if (value is double) return value;
+      if (value is num) return value.toDouble();
+      return double.tryParse(value?.toString() ?? '') ?? 0.0;
+    }
+
+    DateTime parseDateTime(dynamic value) {
+      if (value is DateTime) return value;
+      return DateTime.tryParse(value?.toString() ?? '') ?? DateTime.now();
+    }
+
+    return GiftTransactionModel(
+      id: parseInt(json['id']),
+      senderUserId: parseInt(json['sender_user_id'] ?? json['senderUserId']),
+      recipientUserId: parseInt(
+        json['recipient_user_id'] ?? json['recipientUserId'],
+      ),
+      echoAmount: parseDouble(json['echo_amount'] ?? json['echoAmount']),
+      createdAt: parseDateTime(json['created_at'] ?? json['createdAt']),
+      status: (json['status'] ?? 'completed').toString(),
+      stellarTxHash: json['stellar_tx_hash']?.toString(),
+      message: json['message']?.toString(),
+    );
+  }
 }

--- a/lib/features/socials/view/screens/video_call_screen.dart
+++ b/lib/features/socials/view/screens/video_call_screen.dart
@@ -7,6 +7,7 @@ import 'package:agora_rtc_engine/agora_rtc_engine.dart';
 import 'package:animate_do/animate_do.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import '../../../../core/themes/app_theme.dart';
+import '../../../../core/services/gift_notification_service.dart';
 import '../../../../core/services/pip_service.dart';
 import '../../../../core/services/pip_overlay_service.dart';
 import '../../viewmodel/providers/socials_provider.dart';
@@ -43,7 +44,10 @@ class _VideoCallScreenState extends ConsumerState<VideoCallScreen> {
   String? _agoraAppId;
   String? _agoraToken;
   String? _currentUserName;
+  String? _currentUserId;
   final PipService _pipService = PipService();
+  final GiftNotificationService _giftNotificationService =
+      GiftNotificationService();
   bool _isPipSupported = false;
   bool _isInPipMode = false;
   bool _isNavigatingAway =
@@ -88,12 +92,41 @@ class _VideoCallScreenState extends ConsumerState<VideoCallScreen> {
       final authRepository = ref.read(authRepositoryProvider);
       final currentUser = await authRepository.getCurrentUser();
       final userEmail = currentUser?['email'] as String? ?? 'User';
+      final userId = currentUser?['id']?.toString();
       setState(() {
         _currentUserName = userEmail.split('@').first;
+        _currentUserId = userId;
       });
+      _startGiftNotificationsIfReady();
     } catch (e) {
       debugPrint('[VideoCallScreen] Error loading user info: $e');
     }
+  }
+
+  void _startGiftNotificationsIfReady() {
+    if (!_isConnected || _currentUserId == null || _currentUserId!.isEmpty) {
+      return;
+    }
+
+    _giftNotificationService.startListening(_currentUserId!, (gift) {
+      if (!mounted) return;
+
+      final senderLabel = 'User ${gift.senderUserId}';
+      final amountText = gift.echoAmount.toStringAsFixed(1);
+      final messageText = (gift.message != null && gift.message!.isNotEmpty)
+          ? ' • ${gift.message}'
+          : '';
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '🎁 You received $amountText ECHO from @$senderLabel$messageText',
+          ),
+          duration: const Duration(seconds: 3),
+          backgroundColor: AppTheme.primaryColor,
+        ),
+      );
+    });
   }
 
   Future<void> _initializeAgora() async {
@@ -113,6 +146,7 @@ class _VideoCallScreenState extends ConsumerState<VideoCallScreen> {
         });
         // Re-register event handlers for this new screen instance
         _registerEventHandlers();
+        _startGiftNotificationsIfReady();
         return;
       }
 
@@ -207,6 +241,7 @@ class _VideoCallScreenState extends ConsumerState<VideoCallScreen> {
               _isConnected = true;
             });
           }
+          _startGiftNotificationsIfReady();
         },
         onUserJoined: (RtcConnection connection, int remoteUid, int elapsed) {
           debugPrint('[VideoCallScreen] User joined: $remoteUid');
@@ -489,6 +524,7 @@ class _VideoCallScreenState extends ConsumerState<VideoCallScreen> {
   Future<void> _leaveCall() async {
     try {
       WakelockPlus.disable(); // Allow screen to sleep when leaving call
+      _giftNotificationService.stopListening();
 
       // Clean up the PiP overlay and engine
       PipOverlayService().disposeOverlay();
@@ -510,6 +546,7 @@ class _VideoCallScreenState extends ConsumerState<VideoCallScreen> {
 
   @override
   void dispose() {
+    _giftNotificationService.stopListening();
     // Only end the call if we're not navigating away (PiP mode)
     if (!_isNavigatingAway) {
       WakelockPlus.disable(); // Allow screen to sleep again

--- a/supabase/migrations/20260325183000_issue_120_realtime_gift_notifications.sql
+++ b/supabase/migrations/20260325183000_issue_120_realtime_gift_notifications.sql
@@ -1,0 +1,43 @@
+-- Issue #120: Enable realtime gift notifications for live sessions.
+
+alter table if exists public.gift_transactions enable row level security;
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.tables
+    where table_schema = 'public' and table_name = 'gift_transactions'
+  ) and not exists (
+    select 1
+    from pg_publication_rel pr
+    join pg_publication p on p.oid = pr.prpubid
+    join pg_class c on c.oid = pr.prrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where p.pubname = 'supabase_realtime'
+      and n.nspname = 'public'
+      and c.relname = 'gift_transactions'
+  ) then
+    alter publication supabase_realtime add table public.gift_transactions;
+  end if;
+end $$;
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.tables
+    where table_schema = 'public' and table_name = 'gift_transactions'
+  ) and not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'gift_transactions'
+      and policyname = 'Recipients can receive realtime gift events'
+  ) then
+    create policy "Recipients can receive realtime gift events"
+      on public.gift_transactions
+      for select
+      using (auth.uid()::text = recipient_user_id::text);
+  end if;
+end $$;

--- a/test/core/services/gift_notification_service_test.dart
+++ b/test/core/services/gift_notification_service_test.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'package:echomirror/core/services/gift_notification_service.dart';
+import 'package:echomirror/features/global_mirror/data/models/gift_transaction_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('GiftNotificationService', () {
+    test('emits only newly inserted gift rows after initial snapshot', () async {
+      final controller = StreamController<List<Map<String, dynamic>>>();
+      final received = <GiftTransactionModel>[];
+
+      final service = GiftNotificationService(
+        streamFactory: (_) => controller.stream,
+      );
+
+      service.startListening('user-1', (gift) {
+        received.add(gift);
+      });
+
+      controller.add([
+        {
+          'id': 1,
+          'sender_user_id': 10,
+          'recipient_user_id': 20,
+          'echo_amount': 2.5,
+          'created_at': '2026-03-25T10:00:00Z',
+          'status': 'completed',
+        },
+      ]);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(received, isEmpty);
+
+      controller.add([
+        {
+          'id': 1,
+          'sender_user_id': 10,
+          'recipient_user_id': 20,
+          'echo_amount': 2.5,
+          'created_at': '2026-03-25T10:00:00Z',
+          'status': 'completed',
+        },
+        {
+          'id': 2,
+          'sender_user_id': 30,
+          'recipient_user_id': 20,
+          'echo_amount': 5.0,
+          'created_at': '2026-03-25T10:01:00Z',
+          'status': 'completed',
+          'message': 'Great session!',
+        },
+      ]);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(received.length, 1);
+      expect(received.first.id, 2);
+      expect(received.first.echoAmount, 5.0);
+      expect(received.first.message, 'Great session!');
+
+      service.stopListening();
+      await controller.close();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Supabase migration to enable realtime replication for gift_transactions
- add RLS policy so recipients can subscribe to incoming gift rows
- add GiftNotificationService to subscribe to recipient-specific realtime gift events
- wire gift notifications into VideoCallScreen lifecycle and show in-call snackbar alerts
- add service unit test validating stream parsing and new-row detection

## Notes
- This environment does not have flutter/dart binaries installed, so tests could not be executed locally here.

Closes #120
