### PR TITLE
feat: add future_letters migration with RLS and seed data

### DIFF
--- a/supabase/migrations/20260326000000_future_letters.sql
+++ b/supabase/migrations/20260326000000_future_letters.sql
@@ -1,0 +1,15 @@
+create table future_letters (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade not null,
+  content text not null,
+  created_at timestamptz default now(),
+  unlock_at timestamptz not null
+);
+
+alter table future_letters enable row level security;
+
+create policy "Users can read own letters" on future_letters
+  for select using (auth.uid() = user_id);
+
+create policy "Users can insert own letters" on future_letters
+  for insert with check (auth.uid() = user_id);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -22,3 +22,9 @@ insert into public.video_posts (video_url, mood_tag) values
   ('https://example.com/sample-video-1.mp4', 'happy'),
   ('https://example.com/sample-video-2.mp4', 'calm'),
   ('https://example.com/sample-video-3.mp4', 'motivated');
+
+-- Note: future_letters require a real user_id from auth.users.
+-- Replace the UUIDs below with actual user IDs from your local Supabase instance.
+-- insert into public.future_letters (user_id, content, unlock_at) values
+--   ('00000000-0000-0000-0000-000000000001', 'Keep going — you have grown so much this month!', now() + interval '30 days'),
+--   ('00000000-0000-0000-0000-000000000001', 'Remember why you started. You are doing great.', now() + interval '60 days');


### PR DESCRIPTION
## Summary of changes
Creates the `future_letters` table in Supabase that `getFutureLetters()` in `DashboardRepository` is currently stubbed against. Adds RLS policies so users can only read and insert their own letters. Adds commented seed data for local development.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Migration
- [ ] Documentation

## Checklist
- [x] `flutter analyze` passes
- [x] `dart format` run on changed files
- [x] No scratch/debug files committed
- [x] Closes linked issue (e.g. `Closes #123`)

## Screenshots (for UI changes)
N/A — SQL migration only, no UI changes.

## Testing done
- Ran `supabase db reset` locally  migration applied successfully
- Verified `future_letters` table exists with correct columns
- Confirmed RLS blocks cross-user access

## Acceptance criteria
- [x] Migration file created with valid SQL
- [x] RLS policies added (users only see their own letters)
- [x] Seed data added to `supabase/seed.sql` for local dev