### PR TITLE
Feat/157-wire-stellar-routes

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,16 +6,21 @@
   "scripts": {
     "dev": "ts-node src/index.ts",
     "build": "tsc",
-    "lint": "eslint 'src/**/*.ts' --max-warnings 0 --config .eslintrc.cjs",
+    "lint": "eslint \"src/**/*.ts\" --max-warnings 0 --config .eslintrc.cjs",
     "type-check": "tsc --noEmit",
     "test": "jest --config jest.config.cjs --passWithNoTests"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "@stellar/stellar-sdk": "^12.0.0",
+    "@supabase/supabase-js": "^2.39.0",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",
+    "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.11.5",
     "@types/supertest": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^7.0.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,12 @@
 import express from 'express';
 import { healthRouter } from './routes/health';
+import { stellarRouter } from './routes/stellar';
 
 const app = express();
 
 app.use(express.json());
 app.use('/health', healthRouter);
+app.use('/stellar', stellarRouter);
 
+export { app };
 export default app;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import app from './app';
 
 const PORT = process.env.PORT ?? 3000;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,45 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthenticatedRequest extends Request {
+  userId: string;
+}
+
+export function requireAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    return;
+  }
+
+  const token = authHeader.slice(7);
+  const secret = process.env.JWT_SECRET;
+
+  if (!secret) {
+    res
+      .status(500)
+      .json({ error: 'Server misconfiguration: JWT_SECRET not set' });
+    return;
+  }
+
+  try {
+    const payload = jwt.verify(token, secret) as jwt.JwtPayload;
+    const userId = payload.sub;
+
+    if (!userId) {
+      res.status(401).json({ error: 'Invalid token: missing sub claim' });
+      return;
+    }
+
+    (req as AuthenticatedRequest).userId = userId;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired token' });
+  }
+}
+

--- a/server/src/routes/stellar.ts
+++ b/server/src/routes/stellar.ts
@@ -1,10 +1,237 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth';
+import { supabase } from '../services/supabase';
+import {
+  createWallet,
+  establishTrustline,
+  getWalletBalances,
+  sendEcho,
+} from '../services/stellar';
 
-// We reuse the existing Stellar router logic from the dedicated stellar backend,
-// but expose it under the unified `server/src/routes` structure.
-const { stellarRouter } = require('../../../backend/server/src/routes/stellar') as {
-  stellarRouter: Router;
-};
+export const stellarRouter = Router();
 
-export { stellarRouter };
+// All routes require a valid JWT
+stellarRouter.use(requireAuth);
+
+// POST /stellar/wallet/create
+stellarRouter.post(
+  '/wallet/create',
+  async (req: Request, res: Response, next: NextFunction) => {
+    const userId = (req as AuthenticatedRequest).userId;
+
+    try {
+      const { data: existing } = await supabase
+        .from('user_wallets')
+        .select('public_key')
+        .eq('user_id', userId)
+        .single();
+
+      if (existing) {
+        res.status(409).json({
+          error: 'Wallet already exists for this user',
+          publicKey: existing.public_key,
+        });
+        return;
+      }
+
+      const { publicKey, secretKey } = await createWallet();
+      await establishTrustline(secretKey);
+
+      const { error } = await supabase.from('user_wallets').insert({
+        user_id: userId,
+        public_key: publicKey,
+        secret_key: secretKey,
+      });
+
+      if (error) throw new Error(`Failed to save wallet: ${error.message}`);
+
+      res.status(201).json({ publicKey, funded: true });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// GET /stellar/wallet/balance
+stellarRouter.get(
+  '/wallet/balance',
+  async (req: Request, res: Response, next: NextFunction) => {
+    const userId = (req as AuthenticatedRequest).userId;
+
+    try {
+      const { data: wallet, error } = await supabase
+        .from('user_wallets')
+        .select('public_key')
+        .eq('user_id', userId)
+        .single();
+
+      if (error || !wallet) {
+        res.status(404).json({
+          error: 'Wallet not found. Call POST /stellar/wallet/create first.',
+        });
+        return;
+      }
+
+      const balances = await getWalletBalances(wallet.public_key);
+      res.json({ publicKey: wallet.public_key, ...balances });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// POST /stellar/gift
+stellarRouter.post(
+  '/gift',
+  async (req: Request, res: Response, next: NextFunction) => {
+    const senderId = (req as AuthenticatedRequest).userId;
+    const { recipientUserId, amount, message } = req.body as {
+      recipientUserId: string;
+      amount: string;
+      message?: string;
+    };
+
+    if (!recipientUserId || !amount) {
+      res.status(400).json({ error: 'recipientUserId and amount are required' });
+      return;
+    }
+
+    const parsedAmount = parseFloat(amount);
+    if (isNaN(parsedAmount) || parsedAmount <= 0) {
+      res.status(400).json({ error: 'amount must be a positive number' });
+      return;
+    }
+
+    if (parsedAmount < 1 || parsedAmount > 100) {
+      res.status(400).json({ error: 'amount must be between 1 and 100 ECHO' });
+      return;
+    }
+
+    if (senderId === recipientUserId) {
+      res.status(400).json({ error: 'Cannot gift ECHO to yourself' });
+      return;
+    }
+
+    try {
+      const [senderWallet, recipientWallet] = await Promise.all([
+        supabase
+          .from('user_wallets')
+          .select('public_key, secret_key')
+          .eq('user_id', senderId)
+          .single(),
+        supabase
+          .from('user_wallets')
+          .select('public_key')
+          .eq('user_id', recipientUserId)
+          .single(),
+      ]);
+
+      if (senderWallet.error || !senderWallet.data) {
+        res.status(404).json({ error: 'Sender wallet not found' });
+        return;
+      }
+
+      if (recipientWallet.error || !recipientWallet.data) {
+        res.status(404).json({ error: 'Recipient wallet not found' });
+        return;
+      }
+
+      const balances = await getWalletBalances(senderWallet.data.public_key);
+      if (parseFloat(balances.echo) < parsedAmount) {
+        res.status(422).json({
+          error: 'Insufficient ECHO balance',
+          available: balances.echo,
+          requested: amount,
+        });
+        return;
+      }
+
+      const result = await sendEcho(
+        senderWallet.data.secret_key,
+        recipientWallet.data.public_key,
+        parsedAmount.toFixed(7),
+        message,
+      );
+
+      const { error: insertError } = await supabase
+        .from('gift_transactions')
+        .insert({
+          sender_id: senderId,
+          recipient_id: recipientUserId,
+          amount: parsedAmount,
+          tx_hash: result.txHash,
+          status: 'completed',
+          message: message ?? null,
+        });
+
+      if (insertError) {
+        console.error(
+          '[stellar/gift] Failed to record transaction:',
+          insertError.message,
+        );
+      }
+
+      res.status(201).json(result);
+    } catch (err) {
+      const stellarError = err as Error;
+
+      await supabase.from('gift_transactions').insert({
+        sender_id: senderId,
+        recipient_id: recipientUserId,
+        amount: parsedAmount,
+        tx_hash: null,
+        status: 'failed',
+        message: message ?? null,
+      });
+
+      if (
+        stellarError.message?.includes('op_no_trust') ||
+        stellarError.message?.includes('no trustline')
+      ) {
+        res.status(422).json({ error: 'Recipient has no ECHO trustline' });
+        return;
+      }
+
+      next(stellarError);
+    }
+  },
+);
+
+// GET /stellar/transactions
+stellarRouter.get(
+  '/transactions',
+  async (req: Request, res: Response, next: NextFunction) => {
+    const userId = (req as AuthenticatedRequest).userId;
+
+    const page = Math.max(1, parseInt((req.query.page as string) ?? '1', 10));
+    const limit = Math.min(
+      100,
+      Math.max(1, parseInt((req.query.limit as string) ?? '20', 10)),
+    );
+    const offset = (page - 1) * limit;
+
+    try {
+      const { data, error, count } = await supabase
+        .from('gift_transactions')
+        .select('*', { count: 'exact' })
+        .or(`sender_id.eq.${userId},recipient_id.eq.${userId}`)
+        .order('created_at', { ascending: false })
+        .range(offset, offset + limit - 1);
+
+      if (error) throw new Error(error.message);
+
+      res.json({
+        data: data ?? [],
+        pagination: {
+          page,
+          limit,
+          total: count ?? 0,
+          totalPages: Math.ceil((count ?? 0) / limit),
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 

--- a/server/src/routes/stellar.ts
+++ b/server/src/routes/stellar.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+// We reuse the existing Stellar router logic from the dedicated stellar backend,
+// but expose it under the unified `server/src/routes` structure.
+const { stellarRouter } = require('../../../backend/server/src/routes/stellar') as {
+  stellarRouter: Router;
+};
+
+export { stellarRouter };
+

--- a/server/src/services/stellar.ts
+++ b/server/src/services/stellar.ts
@@ -1,0 +1,137 @@
+import {
+  Asset,
+  Horizon,
+  Keypair,
+  Memo,
+  Networks,
+  Operation,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
+
+const horizonUrl =
+  process.env.STELLAR_HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
+const networkPassphrase =
+  process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
+const assetCode = process.env.STELLAR_ASSET_CODE ?? 'ECHO';
+const issuerPublic = process.env.STELLAR_ISSUER_PUBLIC ?? '';
+const friendbotUrl = 'https://friendbot.stellar.org';
+
+const server = new Horizon.Server(horizonUrl);
+
+function getEchoAsset(): Asset {
+  if (!issuerPublic) {
+    throw new Error('STELLAR_ISSUER_PUBLIC is not configured');
+  }
+  return new Asset(assetCode, issuerPublic);
+}
+
+export interface WalletBalance {
+  xlm: string;
+  echo: string;
+}
+
+export interface GiftResult {
+  txHash: string;
+  amount: string;
+  recipient: string;
+}
+
+export async function createWallet(): Promise<{
+  publicKey: string;
+  secretKey: string;
+}> {
+  const keypair = Keypair.random();
+
+  const response = await fetch(`${friendbotUrl}?addr=${keypair.publicKey()}`);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Friendbot funding failed: ${body}`);
+  }
+
+  return {
+    publicKey: keypair.publicKey(),
+    secretKey: keypair.secret(),
+  };
+}
+
+export async function establishTrustline(secretKey: string): Promise<void> {
+  const keypair = Keypair.fromSecret(secretKey);
+  const account = await server.loadAccount(keypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase,
+  })
+    .addOperation(
+      Operation.changeTrust({
+        asset: getEchoAsset(),
+        limit: '1000000',
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(keypair);
+  await server.submitTransaction(tx);
+}
+
+export async function getWalletBalances(
+  publicKey: string,
+): Promise<WalletBalance> {
+  const account = await server.loadAccount(publicKey);
+
+  let xlm = '0';
+  let echo = '0';
+
+  for (const balance of account.balances) {
+    if (balance.asset_type === 'native') {
+      xlm = balance.balance;
+    } else if (
+      balance.asset_type === 'credit_alphanum4' &&
+      balance.asset_code === assetCode &&
+      balance.asset_issuer === issuerPublic
+    ) {
+      echo = balance.balance;
+    }
+  }
+
+  return { xlm, echo };
+}
+
+export async function sendEcho(
+  senderSecret: string,
+  recipientPublicKey: string,
+  amount: string,
+  memo?: string,
+): Promise<GiftResult> {
+  const senderKeypair = Keypair.fromSecret(senderSecret);
+  const account = await server.loadAccount(senderKeypair.publicKey());
+
+  const builder = new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase,
+  }).addOperation(
+    Operation.payment({
+      destination: recipientPublicKey,
+      asset: getEchoAsset(),
+      amount,
+    }),
+  );
+
+  if (memo) {
+    const truncated = memo.length > 28 ? memo.slice(0, 28) : memo;
+    builder.addMemo(Memo.text(truncated));
+  }
+
+  const tx = builder.setTimeout(30).build();
+  tx.sign(senderKeypair);
+
+  const result = await server.submitTransaction(tx);
+
+  return {
+    txHash: result.hash,
+    amount,
+    recipient: recipientPublicKey,
+  };
+}
+

--- a/server/src/services/supabase.ts
+++ b/server/src/services/supabase.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Avoid throwing at import-time so unrelated routes/tests (e.g. /health) can run
+// without Supabase env vars. If Stellar routes are called without valid env,
+// Supabase will fail at request time.
+const supabaseUrl =
+  process.env.SUPABASE_URL ?? 'http://localhost:54321';
+const serviceRoleKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? 'dummy-service-role-key';
+
+export const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+

--- a/test/features/dashboard/dashboard_screen_test.dart
+++ b/test/features/dashboard/dashboard_screen_test.dart
@@ -1,0 +1,256 @@
+import 'package:echomirror/core/widgets/shimmer_loading.dart';
+import 'package:echomirror/features/ai/data/models/ai_insight_model.dart';
+import 'package:echomirror/features/ai/data/repositories/ai_repository.dart';
+import 'package:echomirror/features/auth/data/repositories/auth_repository.dart';
+import 'package:echomirror/features/auth/viewmodel/providers/auth_provider.dart';
+import 'package:echomirror/features/dashboard/data/models/insight_model.dart';
+import 'package:echomirror/features/dashboard/data/repositories/dashboard_repository.dart';
+import 'package:echomirror/features/dashboard/view/screens/dashboard_screen.dart';
+import 'package:echomirror/features/dashboard/viewmodel/providers/dashboard_provider.dart';
+import 'package:echomirror/features/dashboard/viewmodel/providers/mood_chart_provider.dart';
+import 'package:echomirror/features/logging/data/models/log_entry_model.dart';
+import 'package:echomirror/features/logging/data/repositories/logging_repository.dart';
+import 'package:echomirror/features/logging/viewmodel/providers/logging_provider.dart';
+import 'package:echomirror/features/ai/viewmodel/providers/ai_provider.dart';
+import 'package:echomirror/features/dashboard/data/models/mood_analytics_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class _FakeDashboardNotifier extends DashboardNotifier {
+  _FakeDashboardNotifier(
+    DashboardRepository repository,
+    AsyncValue<List<InsightModel>> initialState,
+  ) : super(repository) {
+    state = initialState;
+  }
+}
+
+class _FakeLoggingNotifier extends LoggingNotifier {
+  _FakeLoggingNotifier(
+    LoggingRepository repository,
+    AsyncValue<List<LogEntryModel>> initialState,
+  ) : super(repository) {
+    state = initialState;
+  }
+}
+
+class _FakeAiInsightNotifier extends AiInsightNotifier {
+  _FakeAiInsightNotifier(
+    this._repo,
+    this._initialState,
+  ) : super(_repo) {
+    state = _initialState;
+  }
+
+  final AiRepository _repo;
+  final AsyncValue<AiInsightModel?> _initialState;
+}
+
+void main() {
+  setUpAll(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  const userId = 'user_1';
+
+  DateTime _today() {
+    final now = DateTime.now();
+    return DateTime(now.year, now.month, now.day);
+  }
+
+  LogEntryModel _log({
+    required String userId,
+    required DateTime date,
+    required int mood,
+  }) {
+    final normalized = DateTime(date.year, date.month, date.day);
+    return LogEntryModel(
+      id: '${userId}_${normalized.toIso8601String()}_${mood}',
+      userId: userId,
+      date: normalized,
+      mood: mood,
+      habits: const [],
+      notes: null,
+      createdAt: normalized,
+    );
+  }
+
+  InsightModel _insight({
+    required String id,
+    required InsightType type,
+  }) {
+    final now = _today();
+    return InsightModel(
+      id: id,
+      userId: userId,
+      title: 'title-$id',
+      description: 'desc-$id',
+      date: now,
+      type: type,
+      createdAt: now,
+    );
+  }
+
+  AiInsightModel _aiInsight({
+    required String futureLetter,
+    int? stressLevel,
+  }) {
+    return AiInsightModel(
+      prediction: 'Test prediction',
+      suggestions: const ['Suggestion 1', 'Suggestion 2'],
+      futureLetter: futureLetter,
+      generatedAt: DateTime.now(),
+      stressLevel: stressLevel,
+      calmingMessage: 'Calm down',
+      musicRecommendations: const ['Song 1'],
+    );
+  }
+
+  Widget _buildScreen({
+    required AsyncValue<List<InsightModel>> dashboardState,
+    required AsyncValue<List<LogEntryModel>> loggingState,
+    AsyncValue<AiInsightModel?>? aiInsightState,
+  }) {
+    final mockAuthRepository = MockAuthRepository();
+    when(() => mockAuthRepository.isAuthenticated())
+        .thenAnswer((_) async => false);
+
+    final loggingRepo = LoggingRepository();
+    final dashboardRepo = DashboardRepository(loggingRepo);
+    final aiRepo = AiRepository();
+
+    return ProviderScope(
+      overrides: [
+        authRepositoryProvider.overrideWithValue(mockAuthRepository),
+        dashboardProvider.overrideWith(
+          (ref) => _FakeDashboardNotifier(dashboardRepo, dashboardState),
+        ),
+        loggingProvider.overrideWith(
+          (ref) => _FakeLoggingNotifier(loggingRepo, loggingState),
+        ),
+        if (aiInsightState != null)
+          aiInsightProvider.overrideWith(
+            (ref) => _FakeAiInsightNotifier(aiRepo, aiInsightState),
+          ),
+        // Ensure the chart provider doesn't depend on auth state in tests.
+        moodChartDataProvider.overrideWithValue(const <LogEntryModel>[]),
+      ],
+      child: const MaterialApp(
+        home: DashboardScreen(),
+      ),
+    );
+  }
+
+  testWidgets('shows empty state when there are no log entries', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildScreen(
+        dashboardState: const AsyncValue.data([]),
+        loggingState: const AsyncValue.data([]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No insights yet'), findsOneWidget);
+    expect(find.text('Start Logging'), findsOneWidget);
+    expect(find.textContaining('day streak'), findsNothing);
+  });
+
+  testWidgets('mood streak card renders correct streak count', (
+    tester,
+  ) async {
+    final today = _today();
+    final yesterday = today.subtract(const Duration(days: 1));
+
+    final logs = <LogEntryModel>[
+      _log(userId: userId, date: today, mood: 4),
+      _log(userId: userId, date: yesterday, mood: 4),
+    ];
+
+    final expectedStreak = MoodAnalyticsModel.computeStreak(logs);
+    expect(expectedStreak, 2);
+
+    await tester.pumpWidget(
+      _buildScreen(
+        dashboardState: AsyncValue.data(
+          [_insight(id: '1', type: InsightType.general)],
+        ),
+        loggingState: AsyncValue.data(logs),
+        aiInsightState: const AsyncValue.data(null),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('\u{1F525} 2-day streak'), findsOneWidget);
+    expect(find.text('Great start, keep going!'), findsOneWidget);
+  });
+
+  testWidgets('AI insight section renders when insight is available', (
+    tester,
+  ) async {
+    final insight = _aiInsight(
+      futureLetter: 'Letter body',
+      stressLevel: 1,
+    );
+
+    await tester.pumpWidget(
+      _buildScreen(
+        dashboardState: AsyncValue.data(
+          [_insight(id: '1', type: InsightType.prediction)],
+        ),
+        loggingState: const AsyncValue.data([]),
+        aiInsightState: AsyncValue.data(insight),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('AI Insights'), findsOneWidget);
+    expect(find.text('AI Insights Coming Soon'), findsNothing);
+  });
+
+  testWidgets('loading state shows shimmer while dashboard is loading', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildScreen(
+        dashboardState: const AsyncValue.loading(),
+        loggingState: const AsyncValue.data([]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ShimmerLoading), findsOneWidget);
+    expect(find.text('No insights yet'), findsNothing);
+  });
+
+  testWidgets('future letter card renders when letter is available', (
+    tester,
+  ) async {
+    const letterText = 'Test future letter body';
+    final insight = _aiInsight(
+      futureLetter: letterText,
+      stressLevel: 1,
+    );
+
+    await tester.pumpWidget(
+      _buildScreen(
+        dashboardState: AsyncValue.data(
+          [_insight(id: '1', type: InsightType.general)],
+        ),
+        loggingState: const AsyncValue.data([]),
+        aiInsightState: AsyncValue.data(insight),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Letter from Future You'), findsOneWidget);
+    expect(find.text(letterText), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
Closes #157

---

Stellar routes wired + branch created
Unified router added at server/src/routes/stellar.ts (full router code, not a cross-project require).

Mounted in main app: server/src/app.ts now includes:

app.use('/stellar', stellarRouter);
app is exported as both named (export { app }) and default (export default app)
Auth middleware applied to all /stellar/* routes via stellarRouter.use(requireAuth) using the ported middleware at server/src/middleware/auth.ts.

Added required services:

server/src/services/supabase.ts (non-throwing defaults so /health and tests don’t crash without env vars)
server/src/services/stellar.ts (fixed for @stellar/stellar-sdk v12 and made asset creation lazy so importing the app doesn’t throw)
Server checks:

npm run type-check ✅
npm test ✅
npm run lint ✅ (also fixed the lint script quoting to work on Windows)
Branch: created and switched to feat/157-wire-stellar-routes (you’re on it now).