### PR TITLE
Fix notifications, future letters, logging mocks, and socials tests

### DIFF
--- a/lib/features/ai/view/widgets/future_letter_card.dart
+++ b/lib/features/ai/view/widgets/future_letter_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:lottie/lottie.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../../../core/themes/app_theme.dart';
 import '../../../../core/animations/lottie_animations.dart';
 import '../../data/models/ai_insight_model.dart';
@@ -19,6 +20,7 @@ class FutureLetterCard extends StatefulWidget {
 class _FutureLetterCardState extends State<FutureLetterCard>
     with TickerProviderStateMixin {
   bool _hasPlayedAnimation = false;
+  bool _hasPersistedLetter = false;
   int _envelopePlayCount = 0;
   late AnimationController _lottieController;
   late AnimationController _sparkleController;
@@ -44,6 +46,7 @@ class _FutureLetterCardState extends State<FutureLetterCard>
         });
         // Start sparkle animation and stop after 5 seconds
         _sparkleController.repeat();
+        _persistFutureLetter();
         Future.delayed(const Duration(seconds: 5), () {
           if (mounted) {
             _sparkleController.stop();
@@ -58,6 +61,40 @@ class _FutureLetterCardState extends State<FutureLetterCard>
     _lottieController.dispose();
     _sparkleController.dispose();
     super.dispose();
+  }
+
+  Future<void> _persistFutureLetter() async {
+    if (_hasPersistedLetter) return;
+
+    final client = Supabase.instance.client;
+    final userId = client.auth.currentUser?.id;
+    final content = widget.insight.futureLetter.trim();
+    if (userId == null || userId.isEmpty || content.isEmpty) return;
+
+    try {
+      final existing = await client
+          .from('future_letters')
+          .select('id')
+          .eq('user_id', userId)
+          .eq('content', content)
+          .maybeSingle();
+
+      if (existing == null) {
+        await client.from('future_letters').insert({
+          'user_id': userId,
+          'content': content,
+          'created_at': widget.insight.generatedAt.toUtc().toIso8601String(),
+          'unlock_at': widget.insight.generatedAt
+              .add(const Duration(days: 30))
+              .toUtc()
+              .toIso8601String(),
+        });
+      }
+
+      _hasPersistedLetter = true;
+    } catch (e) {
+      debugPrint('[FutureLetterCard] Failed to persist future letter: $e');
+    }
   }
 
   @override

--- a/lib/features/dashboard/data/repositories/dashboard_repository.dart
+++ b/lib/features/dashboard/data/repositories/dashboard_repository.dart
@@ -1,15 +1,23 @@
 import '../models/insight_model.dart';
 import '../../../logging/data/repositories/logging_repository.dart';
 import '../../../logging/data/models/log_entry_model.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// Repository for dashboard operations
 /// Handles all Serverpod backend calls for insights and predictions
 class DashboardRepository {
-  DashboardRepository(this._loggingRepository, {DateTime Function()? now})
-    : _now = now ?? DateTime.now;
+  DashboardRepository(
+    this._loggingRepository, {
+    SupabaseClient? supabaseClient,
+    DateTime Function()? now,
+  }) : _supabase = supabaseClient,
+       _now = now ?? DateTime.now;
 
   final LoggingRepository _loggingRepository;
+  final SupabaseClient? _supabase;
   final DateTime Function() _now;
+
+  SupabaseClient get _client => _supabase ?? Supabase.instance.client;
 
   /// Get insights for a user
   /// Generates insights from log entries
@@ -279,13 +287,28 @@ class DashboardRepository {
   /// Get future letters (time capsule feature)
   Future<List<InsightModel>> getFutureLetters(String userId) async {
     try {
-      // Example Serverpod call
-      // final results = await _client.dashboard.getFutureLetters(userId);
-      // return results.map((r) => InsightModel.fromJson(r)).toList();
+      final response = await _client
+          .from('future_letters')
+          .select()
+          .eq('user_id', userId)
+          .order('created_at', ascending: false);
 
-      // Placeholder implementation
-      await Future.delayed(const Duration(seconds: 1));
-      return [];
+      return (response as List<dynamic>)
+          .whereType<Map<String, dynamic>>()
+          .map((row) {
+            final createdAt = DateTime.parse(row['created_at'] as String);
+            final unlockAt = DateTime.parse(row['unlock_at'] as String);
+            return InsightModel(
+              id: row['id'].toString(),
+              userId: row['user_id'].toString(),
+              title: 'Letter from Future You',
+              description: row['content'] as String? ?? '',
+              date: unlockAt,
+              type: InsightType.general,
+              createdAt: createdAt,
+            );
+          })
+          .toList();
     } catch (e) {
       throw Exception('Failed to get future letters: ${e.toString()}');
     }

--- a/lib/features/global_mirror/data/models/mood_comment_notification_model.dart
+++ b/lib/features/global_mirror/data/models/mood_comment_notification_model.dart
@@ -21,14 +21,15 @@ class MoodCommentNotificationModel {
   factory MoodCommentNotificationModel.fromJson(Map<String, dynamic> json) {
     return MoodCommentNotificationModel(
       id: json['id']?.toString() ?? '',
-      moodPinId: json['moodPinId']?.toString() ?? '',
-      commentId: json['commentId']?.toString() ?? '',
-      commentText: json['commentText'] ?? '',
+      moodPinId:
+          (json['moodPinId'] ?? json['mood_pin_id'])?.toString() ?? '',
+      commentId: (json['commentId'] ?? json['comment_id'])?.toString() ?? '',
+      commentText: (json['commentText'] ?? json['comment_text']) ?? '',
       sentiment: json['sentiment'] ?? 'neutral',
-      timestamp: json['timestamp'] != null
-          ? DateTime.parse(json['timestamp'])
+      timestamp: (json['timestamp'] ?? json['created_at']) != null
+          ? DateTime.parse((json['timestamp'] ?? json['created_at']) as String)
           : DateTime.now(),
-      isRead: json['isRead'] ?? false,
+      isRead: (json['isRead'] ?? json['is_read']) as bool? ?? false,
     );
   }
 

--- a/lib/features/global_mirror/viewmodel/providers/mood_comment_notification_provider.dart
+++ b/lib/features/global_mirror/viewmodel/providers/mood_comment_notification_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../data/models/mood_comment_notification_model.dart';
 
 /// Provider for mood comment notifications
@@ -12,22 +13,35 @@ final moodCommentNotificationProvider =
     });
 
 /// State notifier for managing mood comment notifications
-/// NOTE: Supabase endpoint migration pending
 class MoodCommentNotificationNotifier
     extends StateNotifier<List<MoodCommentNotificationModel>> {
   MoodCommentNotificationNotifier() : super([]) {
     _loadNotifications();
   }
 
+  SupabaseClient get _supabase => Supabase.instance.client;
+
+  String? get _currentUserId => _supabase.auth.currentUser?.id;
+
   /// Load notifications
-  /// Note: Returns empty list until Supabase endpoints are implemented
   Future<void> _loadNotifications() async {
-    try {
-      // TODO: Implement via Supabase once endpoints are ready
-      debugPrint(
-        '[MoodCommentNotificationNotifier] Notifications require Supabase endpoint - not yet implemented',
-      );
+    final userId = _currentUserId;
+    if (userId == null || userId.isEmpty) {
       state = [];
+      return;
+    }
+
+    try {
+      final response = await _supabase
+          .from('mood_comment_notifications')
+          .select()
+          .eq('user_id', userId)
+          .order('created_at', ascending: false);
+
+      state = (response as List<dynamic>)
+          .whereType<Map<String, dynamic>>()
+          .map(MoodCommentNotificationModel.fromJson)
+          .toList();
     } catch (e) {
       debugPrint(
         '[MoodCommentNotificationNotifier] Error loading notifications: $e',
@@ -42,16 +56,24 @@ class MoodCommentNotificationNotifier
   }
 
   /// Mark notification as read
-  /// NOTE: Requires Supabase endpoint to be implemented
   Future<void> markAsRead(String notificationId) async {
-    try {
-      final notifIdInt = int.tryParse(notificationId);
-      if (notifIdInt == null) return;
+    final userId = _currentUserId;
+    if (userId == null || userId.isEmpty) return;
 
-      // TODO: Implement via Supabase
-      debugPrint(
-        '[MoodCommentNotificationNotifier] markAsRead not yet implemented for Supabase',
-      );
+    try {
+      await _supabase
+          .from('mood_comment_notifications')
+          .update({'is_read': true})
+          .eq('id', notificationId)
+          .eq('user_id', userId);
+
+      state = [
+        for (final notification in state)
+          if (notification.id == notificationId)
+            notification.copyWith(isRead: true)
+          else
+            notification,
+      ];
     } catch (e) {
       debugPrint(
         '[MoodCommentNotificationNotifier] Error marking notification as read: $e',
@@ -61,12 +83,19 @@ class MoodCommentNotificationNotifier
 
   /// Mark all notifications as read
   Future<void> markAllAsRead() async {
+    final userId = _currentUserId;
+    if (userId == null || userId.isEmpty) return;
+
     try {
-      // TODO: Implement via Supabase
-      debugPrint(
-        '[MoodCommentNotificationNotifier] markAllAsRead not yet implemented for Supabase',
-      );
-      await _loadNotifications();
+      await _supabase
+          .from('mood_comment_notifications')
+          .update({'is_read': true})
+          .eq('user_id', userId)
+          .eq('is_read', false);
+
+      state = [
+        for (final notification in state) notification.copyWith(isRead: true),
+      ];
     } catch (e) {
       debugPrint(
         '[MoodCommentNotificationNotifier] Error marking all notifications as read: $e',
@@ -75,16 +104,20 @@ class MoodCommentNotificationNotifier
   }
 
   /// Delete a notification
-  /// NOTE: Requires Supabase endpoint to be implemented
   Future<void> deleteNotification(String notificationId) async {
-    try {
-      final notifIdInt = int.tryParse(notificationId);
-      if (notifIdInt == null) return;
+    final userId = _currentUserId;
+    if (userId == null || userId.isEmpty) return;
 
-      // TODO: Implement via Supabase
-      debugPrint(
-        '[MoodCommentNotificationNotifier] deleteNotification not yet implemented for Supabase',
-      );
+    try {
+      await _supabase
+          .from('mood_comment_notifications')
+          .delete()
+          .eq('id', notificationId)
+          .eq('user_id', userId);
+
+      state = state
+          .where((notification) => notification.id != notificationId)
+          .toList();
     } catch (e) {
       debugPrint(
         '[MoodCommentNotificationNotifier] Error deleting notification: $e',
@@ -93,14 +126,17 @@ class MoodCommentNotificationNotifier
   }
 
   /// Clear all notifications (delete all)
-  /// NOTE: Requires Supabase endpoint to be implemented
   Future<void> clearAll() async {
+    final userId = _currentUserId;
+    if (userId == null || userId.isEmpty) return;
+
     try {
-      // TODO: Implement via Supabase
-      debugPrint(
-        '[MoodCommentNotificationNotifier] clearAll not yet implemented for Supabase',
-      );
-      await _loadNotifications();
+      await _supabase
+          .from('mood_comment_notifications')
+          .delete()
+          .eq('user_id', userId);
+
+      state = [];
     } catch (e) {
       debugPrint(
         '[MoodCommentNotificationNotifier] Error clearing all notifications: $e',

--- a/supabase/migrations/20260327000000_future_letters_persistence.sql
+++ b/supabase/migrations/20260327000000_future_letters_persistence.sql
@@ -1,0 +1,46 @@
+create table if not exists public.future_letters (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade not null,
+  content text not null,
+  created_at timestamptz default now(),
+  unlock_at timestamptz not null
+);
+
+alter table public.future_letters enable row level security;
+
+create index if not exists idx_future_letters_user_created_at
+  on public.future_letters(user_id, created_at desc);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'future_letters'
+      and policyname = 'Users can read own letters'
+  ) then
+    create policy "Users can read own letters"
+      on public.future_letters
+      for select
+      using (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'future_letters'
+      and policyname = 'Users can insert own letters'
+  ) then
+    create policy "Users can insert own letters"
+      on public.future_letters
+      for insert
+      with check (auth.uid() = user_id);
+  end if;
+end
+$$;

--- a/test/features/logging/logging_repository_test.dart
+++ b/test/features/logging/logging_repository_test.dart
@@ -10,88 +10,76 @@ class MockSupabaseClient extends Mock implements SupabaseClient {}
 
 class MockSupabaseQueryBuilder extends Mock implements SupabaseQueryBuilder {}
 
-/// A lightweight fake that covers filter → transform chains returning a list.
-class FakePostgrestBuilder extends Fake
-    implements PostgrestFilterBuilder<PostgrestList> {
-  final dynamic _result;
+class MockPostgrestListBuilder extends Mock
+    implements PostgrestFilterBuilder<PostgrestList> {}
 
-  FakePostgrestBuilder([this._result]);
+class MockPostgrestMapBuilder extends Mock
+    implements PostgrestTransformBuilder<PostgrestMap> {}
 
-  @override
-  PostgrestFilterBuilder<PostgrestList> eq(String column, Object value) => this;
-  @override
-  PostgrestFilterBuilder<PostgrestList> gte(String column, Object value) =>
-      this;
-  @override
-  PostgrestFilterBuilder<PostgrestList> lte(String column, Object value) =>
-      this;
-  @override
-  PostgrestTransformBuilder<PostgrestList> order(
-    String column, {
-    bool ascending = true,
-    bool nullsFirst = false,
-    String? referencedTable,
-  }) => this;
-  @override
-  PostgrestTransformBuilder<PostgrestList> select([String columns = '*']) =>
-      this;
-  @override
-  PostgrestTransformBuilder<PostgrestMap> single() =>
-      _FakeSingleBuilder(_result);
-  @override
-  PostgrestTransformBuilder<PostgrestMap?> maybeSingle() =>
-      _FakeMaybeSingleBuilder(_result);
+class MockPostgrestNullableMapBuilder extends Mock
+    implements PostgrestTransformBuilder<PostgrestMap?> {}
 
-  @override
-  Future<U> then<U>(
-    FutureOr<U> Function(PostgrestList) onValue, {
-    Function? onError,
-  }) {
-    final list = _result is List<Map<String, dynamic>>
-        ? _result
-        : _result is List
-        ? _result.cast<Map<String, dynamic>>()
-        : <Map<String, dynamic>>[];
-    return Future.value(list).then(onValue, onError: onError);
-  }
+class FakeMapCallback extends Fake {
+  PostgrestMap call(PostgrestMap value) => value;
 }
 
-class _FakeSingleBuilder extends Fake
-    implements PostgrestTransformBuilder<PostgrestMap> {
-  final dynamic _result;
-  _FakeSingleBuilder(this._result);
-
-  @override
-  Future<U> then<U>(
-    FutureOr<U> Function(PostgrestMap) onValue, {
-    Function? onError,
-  }) {
-    return Future.value(
-      _result as PostgrestMap,
-    ).then(onValue, onError: onError);
-  }
+class FakeNullableMapCallback extends Fake {
+  PostgrestMap? call(PostgrestMap? value) => value;
 }
 
-class _FakeMaybeSingleBuilder extends Fake
-    implements PostgrestTransformBuilder<PostgrestMap?> {
-  final dynamic _result;
-  _FakeMaybeSingleBuilder(this._result);
+class FakeListCallback extends Fake {
+  PostgrestList call(PostgrestList value) => value;
+}
 
-  @override
-  Future<U> then<U>(
-    FutureOr<U> Function(PostgrestMap?) onValue, {
-    Function? onError,
-  }) {
-    return Future.value(
-      _result as PostgrestMap?,
-    ).then(onValue, onError: onError);
-  }
+void _stubListAwait(
+  MockPostgrestListBuilder builder,
+  List<Map<String, dynamic>> result,
+) {
+  when(
+    () => builder.then(any(), onError: any(named: 'onError')),
+  ).thenAnswer((invocation) async {
+    final onValue =
+        invocation.positionalArguments.first
+            as FutureOr<dynamic> Function(PostgrestList);
+    return onValue(result);
+  });
+}
+
+void _stubMapAwait(
+  MockPostgrestMapBuilder builder,
+  Map<String, dynamic> result,
+) {
+  when(
+    () => builder.then(any(), onError: any(named: 'onError')),
+  ).thenAnswer((invocation) async {
+    final onValue =
+        invocation.positionalArguments.first
+            as FutureOr<dynamic> Function(PostgrestMap);
+    return onValue(result);
+  });
+}
+
+void _stubNullableMapAwait(
+  MockPostgrestNullableMapBuilder builder,
+  Map<String, dynamic>? result,
+) {
+  when(
+    () => builder.then(any(), onError: any(named: 'onError')),
+  ).thenAnswer((invocation) async {
+    final onValue =
+        invocation.positionalArguments.first
+            as FutureOr<dynamic> Function(PostgrestMap?);
+    return onValue(result);
+  });
 }
 
 void main() {
   late LoggingRepository repository;
   late MockSupabaseClient mockSupabase;
   late MockSupabaseQueryBuilder mockQueryBuilder;
+  late MockPostgrestListBuilder mockListBuilder;
+  late MockPostgrestMapBuilder mockMapBuilder;
+  late MockPostgrestNullableMapBuilder mockNullableMapBuilder;
 
   const userId = '123e4567-e89b-12d3-a456-426614174000';
   final now = DateTime.utc(2026, 3, 25, 12, 0, 0);
@@ -128,21 +116,49 @@ void main() {
     );
   }
 
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+    registerFallbackValue(FakeMapCallback());
+    registerFallbackValue(FakeNullableMapCallback());
+    registerFallbackValue(FakeListCallback());
+  });
+
   setUp(() {
     mockSupabase = MockSupabaseClient();
     mockQueryBuilder = MockSupabaseQueryBuilder();
+    mockListBuilder = MockPostgrestListBuilder();
+    mockMapBuilder = MockPostgrestMapBuilder();
+    mockNullableMapBuilder = MockPostgrestNullableMapBuilder();
     repository = LoggingRepository(supabaseClient: mockSupabase);
+
+    when(
+      () => mockSupabase.from('log_entries'),
+    ).thenAnswer((_) => mockQueryBuilder);
+
+    when(() => mockListBuilder.eq(any(), any())).thenReturn(mockListBuilder);
+    when(() => mockListBuilder.gte(any(), any())).thenReturn(mockListBuilder);
+    when(() => mockListBuilder.lte(any(), any())).thenReturn(mockListBuilder);
+    when(
+      () => mockListBuilder.order(
+        any(),
+        ascending: any(named: 'ascending'),
+        nullsFirst: any(named: 'nullsFirst'),
+        referencedTable: any(named: 'referencedTable'),
+      ),
+    ).thenReturn(mockListBuilder);
+    when(() => mockListBuilder.select(any())).thenReturn(mockListBuilder);
+    when(() => mockListBuilder.single()).thenReturn(mockMapBuilder);
+    when(() => mockListBuilder.maybeSingle()).thenReturn(mockNullableMapBuilder);
   });
 
   group('LoggingRepository', () {
     test('createLogEntry returns LogEntryModel on success', () async {
       final entry = buildEntry();
-      final fakeBuilder = FakePostgrestBuilder(buildLogJson());
 
       when(
-        () => mockSupabase.from('log_entries'),
-      ).thenAnswer((_) => mockQueryBuilder);
-      when(() => mockQueryBuilder.insert(any())).thenAnswer((_) => fakeBuilder);
+        () => mockQueryBuilder.insert(any()),
+      ).thenAnswer((_) => mockListBuilder);
+      _stubMapAwait(mockMapBuilder, buildLogJson());
 
       final result = await repository.createLogEntry(entry);
 
@@ -160,12 +176,11 @@ void main() {
 
     test('updateLogEntry returns updated model on success', () async {
       final entry = buildEntry().copyWith(mood: 5, notes: 'updated');
-      final fakeBuilder = FakePostgrestBuilder(buildLogJson(mood: 5));
 
       when(
-        () => mockSupabase.from('log_entries'),
-      ).thenAnswer((_) => mockQueryBuilder);
-      when(() => mockQueryBuilder.update(any())).thenAnswer((_) => fakeBuilder);
+        () => mockQueryBuilder.update(any()),
+      ).thenAnswer((_) => mockListBuilder);
+      _stubMapAwait(mockMapBuilder, buildLogJson(mood: 5));
 
       final result = await repository.updateLogEntry(entry);
 
@@ -174,12 +189,8 @@ void main() {
     });
 
     test('getLogEntryForDate returns null when no entry exists', () async {
-      final fakeBuilder = FakePostgrestBuilder(null);
-
-      when(
-        () => mockSupabase.from('log_entries'),
-      ).thenAnswer((_) => mockQueryBuilder);
-      when(() => mockQueryBuilder.select()).thenAnswer((_) => fakeBuilder);
+      when(() => mockQueryBuilder.select()).thenAnswer((_) => mockListBuilder);
+      _stubNullableMapAwait(mockNullableMapBuilder, null);
 
       final result = await repository.getLogEntryForDate(now, userId);
 
@@ -195,26 +206,20 @@ void main() {
     });
 
     test('deleteLogEntry completes without error on success', () async {
-      final fakeBuilder = FakePostgrestBuilder(<Map<String, dynamic>>[]);
-
       when(
-        () => mockSupabase.from('log_entries'),
-      ).thenAnswer((_) => mockQueryBuilder);
-      when(() => mockQueryBuilder.delete()).thenAnswer((_) => fakeBuilder);
+        () => mockQueryBuilder.delete(),
+      ).thenAnswer((_) => mockListBuilder);
+      _stubListAwait(mockListBuilder, <Map<String, dynamic>>[]);
 
       await repository.deleteLogEntry('log-1', userId);
-      // Success means no exception thrown
     });
 
     test('getLogEntries filters by startDate and endDate correctly', () async {
       final startDate = DateTime.utc(2026, 3, 1);
       final endDate = DateTime.utc(2026, 3, 31);
-      final fakeBuilder = FakePostgrestBuilder(<Map<String, dynamic>>[]);
 
-      when(
-        () => mockSupabase.from('log_entries'),
-      ).thenAnswer((_) => mockQueryBuilder);
-      when(() => mockQueryBuilder.select()).thenAnswer((_) => fakeBuilder);
+      when(() => mockQueryBuilder.select()).thenAnswer((_) => mockListBuilder);
+      _stubListAwait(mockListBuilder, <Map<String, dynamic>>[]);
 
       await repository.getLogEntries(
         userId,
@@ -222,8 +227,8 @@ void main() {
         endDate: endDate,
       );
 
-      // Verification of filters would require capturing calls on Fake,
-      // but the main goal here is fixing CI types.
+      verify(() => mockListBuilder.gte('date', '2026-03-01')).called(1);
+      verify(() => mockListBuilder.lte('date', '2026-03-31')).called(1);
     });
   });
 }

--- a/test/features/socials/socials_screen_test.dart
+++ b/test/features/socials/socials_screen_test.dart
@@ -1,0 +1,177 @@
+import 'package:echomirror/core/viewmodel/providers/main_tab_index_provider.dart';
+import 'package:echomirror/features/socials/data/models/story_model.dart';
+import 'package:echomirror/features/socials/data/models/video_session_model.dart';
+import 'package:echomirror/features/socials/data/repositories/socials_repository.dart';
+import 'package:echomirror/features/socials/view/screens/socials_screen.dart';
+import 'package:echomirror/features/socials/viewmodel/providers/socials_provider.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeSocialsNotifier extends SocialsNotifier {
+  _FakeSocialsNotifier(this._initialState) : super(SocialsRepository()) {
+    state = _initialState;
+  }
+
+  final SocialsState _initialState;
+
+  @override
+  void startAutoRefresh() {}
+
+  @override
+  void stopAutoRefresh() {}
+
+  @override
+  Future<void> loadActiveSessions({bool silent = false}) async {}
+
+  @override
+  Future<void> loadStories({bool silent = false}) async {}
+}
+
+class MockNavigatorObserver extends Mock implements NavigatorObserver {}
+
+class FakeRoute extends Fake implements Route<dynamic> {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel wakelockChannel = MethodChannel('wakelock_plus');
+  const MethodChannel pipChannel = MethodChannel('com.echomirror.app/pip');
+
+  setUpAll(() {
+    registerFallbackValue(FakeRoute());
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      'user_id': 'user-1',
+      'user_email': 'tester@example.com',
+    });
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(wakelockChannel, (call) async => true);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pipChannel, (call) async {
+          if (call.method == 'isPipSupported' || call.method == 'isInPipMode') {
+            return false;
+          }
+          return true;
+        });
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(wakelockChannel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pipChannel, null);
+  });
+
+  Widget buildScreen(
+    SocialsState state, {
+    NavigatorObserver? navigatorObserver,
+  }) {
+    return ProviderScope(
+      overrides: [
+        mainTabIndexProvider.overrideWith((ref) => 2),
+        socialsProvider.overrideWith((ref) => _FakeSocialsNotifier(state)),
+      ],
+      child: MaterialApp(
+        home: const SocialsScreen(),
+        navigatorObservers: navigatorObserver == null
+            ? const []
+            : [navigatorObserver],
+      ),
+    );
+  }
+
+  VideoSessionModel buildSession() {
+    return VideoSessionModel(
+      id: 'session-1',
+      hostId: 'host-1',
+      hostName: 'Ada',
+      title: 'Evening Check-in',
+      createdAt: DateTime(2026, 3, 27, 10),
+      participantCount: 3,
+      isActive: true,
+    );
+  }
+
+  StoryModel buildStory() {
+    return StoryModel(
+      id: 1,
+      userId: 'user-2',
+      userName: 'Bella',
+      imageUrls: const ['https://example.com/story.jpg'],
+      createdAt: DateTime(2026, 3, 27, 9),
+      expiresAt: DateTime(2026, 3, 28, 9),
+      viewCount: 0,
+      viewedBy: const [],
+      isActive: true,
+    );
+  }
+
+  testWidgets('renders empty state when sessions list is empty', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildScreen(const SocialsState()));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('No Active Sessions'), findsOneWidget);
+    expect(find.text('Your Story'), findsOneWidget);
+  });
+
+  testWidgets('renders session cards when sessions are available', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildScreen(
+        SocialsState(activeSessions: [buildSession()]),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Ada (LIVE)'), findsOneWidget);
+    expect(find.text('Evening Check-in'), findsOneWidget);
+  });
+
+  testWidgets('renders stories bar items', (tester) async {
+    await tester.pumpWidget(
+      buildScreen(
+        SocialsState(stories: [buildStory()]),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Your Story'), findsOneWidget);
+    expect(find.text('Bella'), findsOneWidget);
+  });
+
+  testWidgets('tapping a session card pushes a new route', (tester) async {
+    final observer = MockNavigatorObserver();
+
+    await tester.pumpWidget(
+      buildScreen(
+        SocialsState(activeSessions: [buildSession()]),
+        navigatorObserver: observer,
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    clearInteractions(observer);
+
+    await tester.tap(find.text('Ada (LIVE)'));
+    await tester.pump();
+
+    verify(() => observer.didPush(any(), any())).called(1);
+  });
+
+  testWidgets('notification icon is visible in the app bar', (tester) async {
+    await tester.pumpWidget(buildScreen(const SocialsState()));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byIcon(FontAwesomeIcons.bell), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
This PR resolves four assigned upstream issues in one branch:
- fixes the stubbed mood comment notification provider by wiring all CRUD/read actions to Supabase
- persists AI-generated future letters to Supabase and loads saved letters through `DashboardRepository.getFutureLetters()`
- replaces the broken manual PostgREST fake in `logging_repository_test.dart` with `mocktail`-based mocks
- adds widget coverage for `SocialsScreen` covering empty state, sessions, stories, navigation, and app bar notification affordance

## Changes
### Issue #137
- wired `MoodCommentNotificationNotifier` to `mood_comment_notifications`
- implemented `_loadNotifications()`, `markAsRead()`, `markAllAsRead()`, `deleteNotification()`, and `clearAll()`
- updated the notification model to understand both existing camelCase usage and Supabase snake_case payloads

### Issue #144
- added future-letter persistence from `FutureLetterCard` after successful AI generation
- added an idempotent migration that ensures `future_letters` exists with RLS and an index
- implemented `DashboardRepository.getFutureLetters()` using Supabase

### Issue #140
- removed the manual `FakePostgrestBuilder` implementation that was conflicting with `postgrest` generics
- rewrote the logging repository test setup using `mocktail` mocks for the Supabase/PostgREST chain

### Issue #145
- added `test/features/socials/socials_screen_test.dart`
- covered empty state rendering, session rendering, stories bar rendering, session tap navigation, and the notification icon

## Verification
I was able to complete the code changes and keep the branch clean/committed.
I could not run `dart format`, `flutter analyze`, or `flutter test` in this shell because `dart` and `flutter` are not available on PATH in the current environment.

## Closes
Closes #137
Closes #140
Closes #144
Closes #145