### PR TITLE
chore: remove dead mock data fields and add test coverage for LoggingNotifier and SettingsScreen

### DIFF
--- a/lib/features/global_mirror/data/repositories/global_mirror_repository.dart
+++ b/lib/features/global_mirror/data/repositories/global_mirror_repository.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
@@ -10,25 +9,10 @@ import '../models/mood_pin_comment_model.dart';
 /// Repository for Global Mirror feature
 /// Handles anonymous mood sharing and video posts
 class GlobalMirrorRepository {
-  final bool _useMockData = false;
-
   SupabaseClient get supabase => Supabase.instance.client;
-
-  final List<MoodPinModel> _mockPins = [];
-  final List<VideoPostModel> _mockVideos = [];
-  final List<MoodPinCommentModel> _mockComments = [];
-  Timer? _mockTimer;
 
   /// Stream mood pins in real-time
   Stream<List<MoodPinModel>> streamMoodPins() {
-    if (_useMockData) {
-      // Simulate mock pins
-      return Stream.periodic(
-        const Duration(seconds: 5),
-        (_) => List.from(_mockPins),
-      );
-    }
-
     debugPrint(
       '[GlobalMirrorRepository] Connecting to '
       'streamMoodPins using Supabase Realtime...',
@@ -68,20 +52,6 @@ class GlobalMirrorRepository {
     try {
       final gridLat = MoodPinModel.anonymizeCoordinate(latitude);
       final gridLon = MoodPinModel.anonymizeCoordinate(longitude);
-
-      if (_useMockData) {
-        final pinId = DateTime.now().millisecondsSinceEpoch.toString();
-        final pin = MoodPinModel(
-          id: pinId,
-          sentiment: sentiment,
-          gridLat: gridLat,
-          gridLon: gridLon,
-          timestamp: DateTime.now(),
-          expiresAt: DateTime.now().add(const Duration(hours: 24)),
-        );
-        _mockPins.add(pin);
-        return pinId;
-      }
 
       debugPrint(
         '[GlobalMirrorRepository] Adding mood pin: '
@@ -123,11 +93,6 @@ class GlobalMirrorRepository {
       if (!await file.exists()) {
         debugPrint('[GlobalMirrorRepository] ERROR: Video file does not exist');
         return null;
-      }
-
-      if (_useMockData) {
-        await Future.delayed(const Duration(seconds: 2));
-        return 'mock://video/${DateTime.now().millisecondsSinceEpoch}.mp4';
       }
 
       final bytes = await file.readAsBytes();
@@ -175,11 +140,6 @@ class GlobalMirrorRepository {
         return null;
       }
 
-      if (_useMockData) {
-        await Future.delayed(const Duration(seconds: 1));
-        return 'mock://image/${DateTime.now().millisecondsSinceEpoch}.jpg';
-      }
-
       final bytes = await file.readAsBytes();
       final ext = imagePath.split('.').last;
       final fileName = '${DateTime.now().millisecondsSinceEpoch}.$ext';
@@ -215,11 +175,6 @@ class GlobalMirrorRepository {
     int limit = 10,
   }) async {
     try {
-      if (_useMockData) {
-        final end = (offset + limit).clamp(0, _mockVideos.length);
-        return _mockVideos.sublist(offset, end);
-      }
-
       final response = await supabase
           .from('video_posts')
           .select()
@@ -275,19 +230,6 @@ class GlobalMirrorRepository {
     required String text,
   }) async {
     try {
-      if (_useMockData) {
-        final commentId = DateTime.now().millisecondsSinceEpoch.toString();
-        _mockComments.add(
-          MoodPinCommentModel(
-            id: commentId,
-            moodPinId: moodPinId,
-            text: text,
-            timestamp: DateTime.now(),
-          ),
-        );
-        return commentId;
-      }
-
       final response = await supabase
           .from('mood_pin_comments')
           .insert({
@@ -308,11 +250,6 @@ class GlobalMirrorRepository {
   /// Get comments for a mood pin
   Future<List<MoodPinCommentModel>> getCommentsForPin(String moodPinId) async {
     try {
-      if (_useMockData) {
-        return _mockComments.where((c) => c.moodPinId == moodPinId).toList()
-          ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
-      }
-
       final response = await supabase
           .from('mood_pin_comments')
           .select()
@@ -339,11 +276,6 @@ class GlobalMirrorRepository {
     String sentiment,
     int nearbyCount,
   ) async {
-    if (_useMockData) {
-      return 'Others nearby are feeling similar—many found short '
-          'walks or deep breathing helped today.';
-    }
-
     try {
       final response = await supabase.functions.invoke(
         'generate-encouragement',
@@ -362,9 +294,5 @@ class GlobalMirrorRepository {
       return 'Others nearby are feeling similar—many found short '
           'walks or deep breathing helped today.';
     }
-  }
-
-  void dispose() {
-    _mockTimer?.cancel();
   }
 }

--- a/test/features/logging/logging_provider_test.dart
+++ b/test/features/logging/logging_provider_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:echomirror/features/logging/viewmodel/providers/logging_provider.dart';
+import 'package:echomirror/features/logging/data/repositories/logging_repository.dart';
+import 'package:echomirror/features/logging/data/models/log_entry_model.dart';
+
+class MockLoggingRepository extends Mock implements LoggingRepository {}
+
+LogEntryModel _makeEntry({
+  String id = 'entry_1',
+  String userId = 'user_1',
+  int mood = 3,
+}) {
+  final now = DateTime(2025, 6, 1);
+  return LogEntryModel(
+    id: id,
+    userId: userId,
+    date: now,
+    mood: mood,
+    habits: const ['exercise'],
+    notes: 'test note',
+    createdAt: now,
+  );
+}
+
+void main() {
+  group('LoggingNotifier', () {
+    late MockLoggingRepository mockRepo;
+    late LoggingNotifier notifier;
+
+    setUp(() {
+      mockRepo = MockLoggingRepository();
+      notifier = LoggingNotifier(mockRepo);
+    });
+
+    test('initial state is AsyncData([])', () {
+      expect(notifier.state, const AsyncValue<List<LogEntryModel>>.data([]));
+    });
+
+    test('loadLogEntries returns empty data when userId is null or empty', () async {
+      await notifier.loadLogEntries(userId: null);
+      expect(notifier.state, const AsyncValue<List<LogEntryModel>>.data([]));
+
+      await notifier.loadLogEntries(userId: '');
+      expect(notifier.state, const AsyncValue<List<LogEntryModel>>.data([]));
+
+      verifyNever(() => mockRepo.getLogEntries(any()));
+    });
+
+    test('loadLogEntries — success: state becomes AsyncData with list', () async {
+      final entries = [_makeEntry(id: 'e1'), _makeEntry(id: 'e2')];
+      when(() => mockRepo.getLogEntries('user_1')).thenAnswer((_) async => entries);
+
+      await notifier.loadLogEntries(userId: 'user_1');
+
+      expect(notifier.state, AsyncValue<List<LogEntryModel>>.data(entries));
+      verify(() => mockRepo.getLogEntries('user_1')).called(1);
+    });
+
+    test('loadLogEntries — failure: state becomes AsyncError', () async {
+      when(
+        () => mockRepo.getLogEntries('user_err'),
+      ).thenThrow(Exception('network error'));
+
+      await notifier.loadLogEntries(userId: 'user_err');
+
+      expect(notifier.state, isA<AsyncError>());
+    });
+
+    test('loadLogEntries does not reload when already loaded for same user', () async {
+      final entries = [_makeEntry()];
+      when(() => mockRepo.getLogEntries('user_1')).thenAnswer((_) async => entries);
+
+      await notifier.loadLogEntries(userId: 'user_1');
+      await notifier.loadLogEntries(userId: 'user_1');
+
+      verify(() => mockRepo.getLogEntries('user_1')).called(1);
+    });
+
+    test('createLogEntry — returns true on success and appends entry to state', () async {
+      final existing = _makeEntry(id: 'e_old');
+      final newEntry = _makeEntry(id: 'e_new', mood: 5);
+      final created = _makeEntry(id: 'e_new_server', mood: 5);
+
+      when(() => mockRepo.getLogEntries('user_1')).thenAnswer((_) async => [existing]);
+      when(() => mockRepo.createLogEntry(any())).thenAnswer((_) async => created);
+
+      await notifier.loadLogEntries(userId: 'user_1');
+      final result = await notifier.createLogEntry(newEntry);
+
+      expect(result, isTrue);
+      final data = notifier.state.value;
+      expect(data, isNotNull);
+      expect(data!.length, 2);
+      expect(data.last, created);
+    });
+
+    test('createLogEntry — returns false on repository error', () async {
+      when(() => mockRepo.createLogEntry(any())).thenThrow(Exception('write failed'));
+
+      final result = await notifier.createLogEntry(_makeEntry());
+
+      expect(result, isFalse);
+      expect(notifier.state, isA<AsyncError>());
+    });
+
+    test('updateLogEntry — returns true on success and updates entry in state', () async {
+      final original = _makeEntry(id: 'e1', mood: 2);
+      final updated = _makeEntry(id: 'e1', mood: 4);
+
+      when(() => mockRepo.getLogEntries('user_1')).thenAnswer((_) async => [original]);
+      when(() => mockRepo.updateLogEntry(any())).thenAnswer((_) async => updated);
+
+      await notifier.loadLogEntries(userId: 'user_1');
+      final result = await notifier.updateLogEntry(updated);
+
+      expect(result, isTrue);
+      final data = notifier.state.value;
+      expect(data, isNotNull);
+      expect(data!.first.mood, 4);
+    });
+
+    test('updateLogEntry — returns false on repository error', () async {
+      when(() => mockRepo.updateLogEntry(any())).thenThrow(Exception('update failed'));
+
+      final result = await notifier.updateLogEntry(_makeEntry());
+
+      expect(result, isFalse);
+      expect(notifier.state, isA<AsyncError>());
+    });
+
+    test('deleteLogEntry — removes entry from state', () async {
+      final e1 = _makeEntry(id: 'e1');
+      final e2 = _makeEntry(id: 'e2', mood: 5);
+
+      when(() => mockRepo.getLogEntries('user_1')).thenAnswer((_) async => [e1, e2]);
+      when(() => mockRepo.deleteLogEntry(any(), any())).thenAnswer((_) async {});
+
+      await notifier.loadLogEntries(userId: 'user_1');
+      final result = await notifier.deleteLogEntry('e1', 'user_1');
+
+      expect(result, isTrue);
+      final data = notifier.state.value;
+      expect(data, isNotNull);
+      expect(data!.length, 1);
+      expect(data.first.id, 'e2');
+    });
+
+    test('deleteLogEntry — returns false on repository error', () async {
+      when(() => mockRepo.getLogEntries('user_1')).thenAnswer((_) async => [_makeEntry()]);
+      when(() => mockRepo.deleteLogEntry(any(), any())).thenThrow(Exception('delete failed'));
+
+      await notifier.loadLogEntries(userId: 'user_1');
+      final result = await notifier.deleteLogEntry('e1', 'user_1');
+
+      expect(result, isFalse);
+      expect(notifier.state, isA<AsyncError>());
+    });
+
+    test('getLogEntryForDate — returns null when userId is not set', () async {
+      final result = await notifier.getLogEntryForDate(DateTime(2025, 6, 1));
+      expect(result, isNull);
+    });
+
+    test('getLogEntryForDate — returns entry from repository when userId is set', () async {
+      final date = DateTime(2025, 6, 1);
+      final entry = _makeEntry();
+
+      when(() => mockRepo.getLogEntries('user_1')).thenAnswer((_) async => [entry]);
+      when(
+        () => mockRepo.getLogEntryForDate(date, 'user_1'),
+      ).thenAnswer((_) async => entry);
+
+      await notifier.loadLogEntries(userId: 'user_1');
+      final result = await notifier.getLogEntryForDate(date);
+
+      expect(result, entry);
+    });
+
+    test('getLogEntryForDate — returns null when repository returns null', () async {
+      final date = DateTime(2025, 6, 2);
+
+      when(() => mockRepo.getLogEntries('user_1')).thenAnswer((_) async => []);
+      when(
+        () => mockRepo.getLogEntryForDate(date, 'user_1'),
+      ).thenAnswer((_) async => null);
+
+      await notifier.loadLogEntries(userId: 'user_1');
+      final result = await notifier.getLogEntryForDate(date);
+
+      expect(result, isNull);
+    });
+
+    test('loggingProvider creates a LoggingNotifier via ProviderContainer', () {
+      final container = ProviderContainer(
+        overrides: [
+          loggingRepositoryProvider.overrideWithValue(mockRepo),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = container.read(loggingProvider);
+      expect(state, const AsyncValue<List<LogEntryModel>>.data([]));
+    });
+  });
+}

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -1,0 +1,223 @@
+import 'package:echomirror/core/viewmodel/providers/notification_provider.dart';
+import 'package:echomirror/core/viewmodel/providers/theme_provider.dart';
+import 'package:echomirror/features/auth/data/repositories/auth_repository.dart';
+import 'package:echomirror/features/auth/viewmodel/providers/auth_provider.dart';
+import 'package:echomirror/features/global_mirror/data/models/gift_transaction_model.dart';
+import 'package:echomirror/features/global_mirror/data/repositories/gift_repository.dart';
+import 'package:echomirror/features/global_mirror/viewmodel/providers/gift_provider.dart';
+import 'package:echomirror/features/settings/view/screens/settings_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes & mocks
+// ---------------------------------------------------------------------------
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class _FakeGiftRepository extends GiftRepository {
+  @override
+  Future<double> getEchoBalance() async => 75.0;
+
+  @override
+  Future<List<GiftTransactionModel>> getGiftHistory() async =>
+      const <GiftTransactionModel>[];
+}
+
+class _FakeGiftNotifier extends GiftNotifier {
+  _FakeGiftNotifier() : super(_FakeGiftRepository()) {
+    state = const GiftState(echoBalance: 75.0);
+  }
+
+  @override
+  Future<void> loadBalance() async {}
+
+  @override
+  Future<void> loadHistory() async {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Builds a [ProviderScope]-wrapped [SettingsScreen] without a real router.
+/// Suitable for tests that do not exercise navigation.
+Widget _buildScreen({
+  ThemeMode initialThemeMode = ThemeMode.light,
+  MockAuthRepository? authRepo,
+  bool notificationsEnabled = false,
+}) {
+  final mockAuth = authRepo ?? MockAuthRepository();
+  when(() => mockAuth.isAuthenticated()).thenAnswer((_) async => true);
+  when(() => mockAuth.getCurrentUser()).thenAnswer(
+    (_) async => {
+      'id': 'user_test',
+      'email': 'tester@example.com',
+      'name': null,
+      'avatarUrl': null,
+      'createdAt': DateTime(2025).toIso8601String(),
+    },
+  );
+
+  return ProviderScope(
+    overrides: [
+      authRepositoryProvider.overrideWithValue(mockAuth),
+      giftProvider.overrideWith((_) => _FakeGiftNotifier()),
+      notificationEnabledProvider.overrideWith((_) async => notificationsEnabled),
+      notificationTimeProvider.overrideWith((_) async => (hour: 8, minute: 0)),
+    ],
+    child: MaterialApp(
+      theme: ThemeData.light(),
+      darkTheme: ThemeData.dark(),
+      themeMode: initialThemeMode,
+      home: const SettingsScreen(),
+    ),
+  );
+}
+
+/// Builds a router-wrapped [SettingsScreen] for navigation tests.
+Widget _buildScreenWithRouter({MockAuthRepository? authRepo}) {
+  final mockAuth = authRepo ?? MockAuthRepository();
+  when(() => mockAuth.isAuthenticated()).thenAnswer((_) async => true);
+  when(() => mockAuth.getCurrentUser()).thenAnswer(
+    (_) async => {
+      'id': 'user_test',
+      'email': 'tester@example.com',
+      'name': null,
+      'avatarUrl': null,
+      'createdAt': DateTime(2025).toIso8601String(),
+    },
+  );
+
+  final router = GoRouter(
+    initialLocation: '/settings',
+    routes: [
+      GoRoute(
+        path: '/settings',
+        builder: (_, __) => const SettingsScreen(),
+      ),
+      GoRoute(
+        path: '/settings/change-password',
+        builder: (_, __) =>
+            const Scaffold(body: Text('Change Password Screen')),
+      ),
+      GoRoute(
+        path: '/gift/:userId',
+        builder: (_, __) => const Scaffold(body: Text('Gift Screen')),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      authRepositoryProvider.overrideWithValue(mockAuth),
+      giftProvider.overrideWith((_) => _FakeGiftNotifier()),
+      notificationEnabledProvider.overrideWith((_) async => false),
+      notificationTimeProvider.overrideWith((_) async => (hour: 8, minute: 0)),
+    ],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  setUpAll(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('renders all section headers and key setting tiles', (tester) async {
+    await tester.pumpWidget(_buildScreen());
+    await tester.pumpAndSettle();
+
+    // Section headers
+    expect(find.text('Appearance'), findsOneWidget);
+    expect(find.text('Reminders'), findsOneWidget);
+    expect(find.text('Account'), findsOneWidget);
+
+    // Key tiles
+    expect(find.text('Dark Mode'), findsOneWidget);
+    expect(find.text('System Theme'), findsOneWidget);
+    expect(find.text('Change Password'), findsOneWidget);
+  });
+
+  testWidgets('dark mode switch changes themeProvider state to ThemeMode.dark',
+      (tester) async {
+    await tester.pumpWidget(_buildScreen());
+    await tester.pumpAndSettle();
+
+    // The switch for Dark Mode should start off (light theme)
+    final switchFinders = find.byType(Switch);
+    // The first Switch in the card is the Dark Mode switch
+    final darkModeSwitch = switchFinders.first;
+    expect(tester.widget<Switch>(darkModeSwitch).value, isFalse);
+
+    await tester.tap(darkModeSwitch);
+    await tester.pumpAndSettle();
+
+    // After tapping, the switch reflects dark mode on
+    expect(tester.widget<Switch>(darkModeSwitch).value, isTrue);
+  });
+
+  testWidgets('system theme switch is visible and can be toggled', (tester) async {
+    await tester.pumpWidget(_buildScreen());
+    await tester.pumpAndSettle();
+
+    expect(find.text('System Theme'), findsOneWidget);
+
+    // There are two switches in the Appearance card — System Theme is second
+    final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
+    expect(switches.length, greaterThanOrEqualTo(2));
+
+    final systemThemeSwitch = switches[1];
+    // Initially follows light mode, so system theme switch is off
+    expect(systemThemeSwitch.value, isFalse);
+  });
+
+  testWidgets(
+      'tapping Change Password navigates to the change-password route',
+      (tester) async {
+    await tester.pumpWidget(_buildScreenWithRouter());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Change Password'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Change Password Screen'), findsOneWidget);
+  });
+
+  testWidgets('Daily Reflection Reminder tile is visible and interactive',
+      (tester) async {
+    await tester.pumpWidget(_buildScreen());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Daily Reflection Reminder'), findsOneWidget);
+
+    // Notification toggle switch should be present
+    final notifSwitch = find.byWidgetPredicate(
+      (widget) => widget is Switch,
+    );
+    expect(notifSwitch, findsWidgets);
+  });
+
+  testWidgets('ECHO balance tile shows balance from giftProvider', (tester) async {
+    await tester.pumpWidget(_buildScreen());
+    await tester.pumpAndSettle();
+
+    expect(find.text('ECHO Balance'), findsOneWidget);
+    expect(find.textContaining('75'), findsOneWidget);
+  });
+
+  testWidgets('email tile displays authenticated user email', (tester) async {
+    await tester.pumpWidget(_buildScreen());
+    await tester.pumpAndSettle();
+
+    expect(find.text('tester@example.com'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #175
Closes #174
Closes #178

## Summary

### #175 — Remove dead mock data fields from `GlobalMirrorRepository`

`GlobalMirrorRepository` carried five fields that could never execute — `_useMockData` was hardcoded to `false` and never toggled, making every `if (_useMockData)` branch unreachable dead code:

- Deleted `_useMockData`, `_mockPins`, `_mockVideos`, `_mockComments`, and `_mockTimer`
- Removed every `if (_useMockData) { … }` block from `streamMoodPins`, `addMoodPin`, `uploadVideo`, `uploadImage`, `getVideoFeed`, `addComment`, `getCommentsForPin`, and `generateClusterEncouragement`
- Removed the now-empty `dispose()` method
- Removed the unused `dart:async` import (the only consumer was `Timer`)

No logic changes — pure deletion.

---

### #174 — Unit tests for `LoggingNotifier`

New file: `test/features/logging/logging_provider_test.dart`

Follows the pattern established in `test/features/dashboard/dashboard_provider_test.dart`. Uses `mocktail` to mock `LoggingRepository` and drives `LoggingNotifier` directly. **12 test cases** covering:

| Method | Cases |
|---|---|
| `loadLogEntries` | null/empty userId → empty data; success → `AsyncData`; failure → `AsyncError`; already-loaded cache → repo called only once |
| `createLogEntry` | success → returns `true`, entry appended; failure → returns `false`, state is `AsyncError` |
| `updateLogEntry` | success → returns `true`, entry updated in-place; failure → returns `false`, state is `AsyncError` |
| `deleteLogEntry` | success → returns `true`, entry removed; failure → returns `false`, state is `AsyncError` |
| `getLogEntryForDate` | no userId → `null`; found → returns entry; not found → `null` |
| `loggingProvider` | `ProviderContainer` smoke-test → initial state is `AsyncData([])` |

---

### #178 — Widget tests for `SettingsScreen`

New file: `test/features/settings/settings_screen_test.dart`

Uses `ProviderScope` overrides to inject mock state (no real Supabase or notification plugin calls). A `GoRouter` setup is provided for the navigation test. **7 test cases**:

1. **Renders all section headers and key tiles** — asserts `Appearance`, `Reminders`, `Account`, `Dark Mode`, `System Theme`, and `Change Password` are all present
2. **Dark mode switch toggles theme state** — taps the Dark Mode `Switch`; asserts its value flips to `true` (light → dark)
3. **System theme switch is visible** — finds at least two `Switch` widgets in the Appearance card and verifies the second starts unchecked
4. **Change Password navigates to change-password route** — uses `GoRouter`; taps the tile; asserts the destination screen is rendered
5. **Notification reminder tile is present and interactive** — finds `Daily Reflection Reminder` and a notification `Switch`
6. **ECHO balance tile shows balance** — asserts `ECHO Balance` label and `75` from the fake `GiftState` are visible
7. **Email tile shows authenticated user email** — asserts `tester@example.com` is rendered after auth check settles

## Test plan

- [ ] `flutter analyze` passes clean (no new warnings)
- [ ] `flutter test test/features/logging/logging_provider_test.dart` — all 12 cases green
- [ ] `flutter test test/features/settings/settings_screen_test.dart` — all 7 cases green
- [ ] All existing tests continue to pass