### PR TITLE
feat: add health check endpoint and startup env var validation

### DIFF
--- a/backend/server/src/index.ts
+++ b/backend/server/src/index.ts
@@ -2,7 +2,20 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import { stellarRouter } from './routes/stellar';
+import { healthRouter } from './routes/health';
 import { errorHandler } from './middleware/errorHandler';
+
+const REQUIRED_ENV_VARS = [
+  'SUPABASE_URL',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'STELLAR_SECRET_KEY',
+  'ECHO_ASSET_ISSUER',
+];
+
+const missing = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);
+if (missing.length > 0) {
+  throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+}
 
 const app = express();
 const PORT = process.env.PORT ?? 3000;
@@ -10,10 +23,7 @@ const PORT = process.env.PORT ?? 3000;
 app.use(cors());
 app.use(express.json());
 
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok' });
-});
-
+app.use('/health', healthRouter);
 app.use('/stellar', stellarRouter);
 
 app.use(errorHandler);
@@ -21,3 +31,5 @@ app.use(errorHandler);
 app.listen(PORT, () => {
   console.log(`EchoMirror Stellar server running on port ${PORT}`);
 });
+
+export { app };

--- a/backend/server/src/routes/health.test.ts
+++ b/backend/server/src/routes/health.test.ts
@@ -1,0 +1,16 @@
+import request from 'supertest';
+import express from 'express';
+import { healthRouter } from './health';
+
+const app = express();
+app.use('/health', healthRouter);
+
+describe('GET /health', () => {
+  it('returns 200 with status ok and a timestamp', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(typeof res.body.timestamp).toBe('string');
+    expect(new Date(res.body.timestamp).toISOString()).toBe(res.body.timestamp);
+  });
+});

--- a/backend/server/src/routes/health.ts
+++ b/backend/server/src/routes/health.ts
@@ -1,0 +1,7 @@
+import { Router, Request, Response } from 'express';
+
+export const healthRouter = Router();
+
+healthRouter.get('/', (_req: Request, res: Response) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});


### PR DESCRIPTION
feat: add Node.js server health check endpoint and startup validation

Closes #148 

Summary
Adds a GET /health endpoint to the Express server and startup validation for required environment variables, ensuring the server fails fast with a clear error if misconfigured.

Changes
health.ts
 (new)

Dedicated router for the health check endpoint
Returns { status: 'ok', timestamp: <ISO 8601 string> } on GET /health
index.ts

Removed the inline /health stub and wired up the new healthRouter
Added startup validation that checks for all required env vars on boot:
SUPABASE_URL
SUPABASE_SERVICE_ROLE_KEY
STELLAR_SECRET_KEY
ECHO_ASSET_ISSUER
Throws a descriptive error listing all missing vars if any are absent, preventing silent misconfigurations
Exports app to support testing without starting the server
health.test.ts
 (new)

Supertest integration test for GET /health
Asserts 200 status, status: 'ok' in body, and a valid ISO timestamp
How to test
cd backend/server
npm test
To verify the env var validation manually, unset one of the required vars and start the server — it should exit immediately with a message like:

Error: Missing required environment variables: SUPABASE_URL, STELLAR_SECRET_KEY
Acceptance Criteria
 GET /health returns 200 with { status: 'ok', timestamp: "..." }
 Server fails fast with a readable error if any required env vars are missing
 /health test added using supertest