### PR TITLE
fix(logging): handle missing Supabase tables with clear UI errors

### DIFF
--- a/lib/features/logging/data/repositories/logging_repository.dart
+++ b/lib/features/logging/data/repositories/logging_repository.dart
@@ -139,8 +139,8 @@ class LoggingRepository {
     } catch (e, stackTrace) {
       debugPrint('[LoggingRepository] getLogEntries error -> $e');
       debugPrint('[LoggingRepository] getLogEntries stackTrace -> $stackTrace');
-      // Return empty list on error instead of throwing
-      return [];
+      // Bubble up Supabase failures so the UI can show actionable errors.
+      throw Exception('Failed to fetch log entries: ${e.toString()}');
     }
   }
 

--- a/lib/features/logging/view/screens/logging_screen.dart
+++ b/lib/features/logging/view/screens/logging_screen.dart
@@ -20,14 +20,14 @@ class LoggingScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final loggingState = ref.watch(loggingProvider);
     final authState = ref.watch(authProvider);
+    final userId = authState.user?.id;
     final theme = Theme.of(context);
 
     // Load log entries when we have a user ID (only once)
     if (authState.isAuthenticated && authState.user != null) {
-      final userId = authState.user!.id;
       // Use addPostFrameCallback to avoid calling during build
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (userId.isNotEmpty) {
+        if (userId != null && userId.isNotEmpty) {
           ref.read(loggingProvider.notifier).loadLogEntries(userId: userId);
         }
       });
@@ -49,7 +49,7 @@ class LoggingScreen extends ConsumerWidget {
       body: RefreshIndicator(
         onRefresh: () => ref
             .read(loggingProvider.notifier)
-            .loadLogEntries(userId: ref.read(authProvider).user?.id),
+            .loadLogEntries(userId: userId),
         child: loggingState.when(
           data: (entries) {
             if (entries.isEmpty) {
@@ -135,8 +135,11 @@ class LoggingScreen extends ConsumerWidget {
           },
           loading: () =>
               const Center(child: ShimmerLoading(width: 40, height: 40)),
-          error: (error, stack) =>
-              NoConnectionWidget(onRetry: () => ref.refresh(loggingProvider)),
+          error: (error, stack) => NoConnectionWidget(
+            message:
+                'We could not load your daily logs. This can happen when Supabase tables are missing. Run migrations and try again.',
+            onRetry: () => _retryLoadEntries(ref, userId),
+          ),
         ),
       ),
       floatingActionButton: FloatingActionButton.extended(
@@ -149,6 +152,11 @@ class LoggingScreen extends ConsumerWidget {
         foregroundColor: Colors.white,
       ),
     );
+  }
+
+  void _retryLoadEntries(WidgetRef ref, String? userId) {
+    if (userId == null || userId.isEmpty) return;
+    ref.read(loggingProvider.notifier).loadLogEntries(userId: userId);
   }
 
   IconData _getMoodIcon(int? mood) {

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -53,6 +53,30 @@ supabase migration new my_migration_name
 supabase db diff
 ```
 
+If you are using a hosted Supabase project (not local Docker), apply pending migrations with:
+
+```bash
+supabase link --project-ref <your-project-ref>
+supabase db push
+```
+
+### Troubleshooting Missing Tables (PGRST205)
+
+If the app logs errors such as `Could not find the table 'public.log_entries' in the schema cache`, your connected Supabase project is missing one or more migrations.
+
+1. Ensure the project is linked (`supabase link --project-ref ...`)
+2. Push migrations (`supabase db push`)
+3. Verify these tables exist in the Supabase SQL editor:
+   - `public.log_entries`
+   - `public.mood_comment_notifications`
+   - `public.video_sessions`
+   - `public.stories`
+   - `public.scheduled_sessions`
+   - `public.user_wallets`
+   - `public.gift_transactions`
+
+After migrations are applied, restart the Flutter app and retry the affected screen.
+
 ## Access Model
 
 The Supabase schema uses Row Level Security on every application table.


### PR DESCRIPTION
## Summary
- Surface `log_entries` fetch failures from `LoggingRepository` instead of silently returning an empty list.
- Show a meaningful error state and explicit retry flow in `LoggingScreen` when Supabase tables are unreachable.
- Add hosted Supabase migration troubleshooting docs (`supabase db push`) and required table checks.
- Closes #190
- Closes #193
- Closes #196


## Test plan
- [ ] Run `flutter test test/features/logging/logging_provider_test.dart`
- [ ] Reproduce missing-table state by pointing app at an un-migrated Supabase project
- [ ] Verify Logging screen shows error message + retry button
- [ ] Apply migrations with `supabase db push` and verify entries load normally

