### PR TITLE
mood-notification

### DIFF
--- a/lib/features/global_mirror/data/repositories/global_mirror_repository.dart
+++ b/lib/features/global_mirror/data/repositories/global_mirror_repository.dart
@@ -88,7 +88,9 @@ class GlobalMirrorRepository {
             'user_id': userId,
             'mood_pin_id': pinId,
           });
-          debugPrint('[GlobalMirrorRepository] Linked pin $pinId to user $userId');
+          debugPrint(
+            '[GlobalMirrorRepository] Linked pin $pinId to user $userId',
+          );
         } catch (e) {
           debugPrint('[GlobalMirrorRepository] Error linking pin to user: $e');
           // Non-critical, so we don't return null here

--- a/lib/features/global_mirror/data/repositories/global_mirror_repository.dart
+++ b/lib/features/global_mirror/data/repositories/global_mirror_repository.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import '../models/mood_pin_model.dart';
 import '../models/video_post_model.dart';
 import '../models/mood_pin_comment_model.dart';
+import '../core/services/user_mood_pins_service.dart';
 
 /// Repository for Global Mirror feature
 /// Handles anonymous mood sharing and video posts
@@ -75,6 +76,25 @@ class GlobalMirrorRepository {
 
       final pinId = response['id'].toString();
       debugPrint('[GlobalMirrorRepository] Added mood pin - Pin ID: $pinId');
+
+      // Track locally for UI purposes (my pins vs others)
+      await UserMoodPinsService.addMoodPinId(pinId);
+
+      // Link to user in database to enable notifications
+      final userId = supabase.auth.currentUser?.id;
+      if (userId != null) {
+        try {
+          await supabase.from('user_mood_pins').insert({
+            'user_id': userId,
+            'mood_pin_id': pinId,
+          });
+          debugPrint('[GlobalMirrorRepository] Linked pin $pinId to user $userId');
+        } catch (e) {
+          debugPrint('[GlobalMirrorRepository] Error linking pin to user: $e');
+          // Non-critical, so we don't return null here
+        }
+      }
+
       return pinId;
     } catch (e, stackTrace) {
       debugPrint('[GlobalMirrorRepository] Error adding mood pin: $e');

--- a/lib/features/logging/view/screens/logging_screen.dart
+++ b/lib/features/logging/view/screens/logging_screen.dart
@@ -48,8 +48,8 @@ class LoggingScreen extends ConsumerWidget {
       ),
       body: RefreshIndicator(
         onRefresh: () => ref.read(loggingProvider.notifier).loadLogEntries(
-              userId: userId,
-            ),
+          userId: userId,
+        ),
         child: loggingState.when(
           data: (entries) {
             if (entries.isEmpty) {
@@ -136,8 +136,9 @@ class LoggingScreen extends ConsumerWidget {
           loading: () =>
               const Center(child: ShimmerLoading(width: 40, height: 40)),
           error: (error, stack) => NoConnectionWidget(
-            message:
-                'We could not load your daily logs. This can happen when Supabase tables are missing. Run migrations and try again.',
+            message: 'We could not load your daily logs. '
+                'This can happen when Supabase tables are missing. '
+                'Run migrations and try again.',
             onRetry: () => _retryLoadEntries(ref, userId),
           ),
         ),

--- a/lib/features/logging/view/screens/logging_screen.dart
+++ b/lib/features/logging/view/screens/logging_screen.dart
@@ -47,8 +47,9 @@ class LoggingScreen extends ConsumerWidget {
         ],
       ),
       body: RefreshIndicator(
-        onRefresh: () =>
-            ref.read(loggingProvider.notifier).loadLogEntries(userId: userId),
+        onRefresh: () => ref
+            .read(loggingProvider.notifier)
+            .loadLogEntries(userId: userId),
         child: loggingState.when(
           data: (entries) {
             if (entries.isEmpty) {

--- a/lib/features/logging/view/screens/logging_screen.dart
+++ b/lib/features/logging/view/screens/logging_screen.dart
@@ -133,8 +133,12 @@ class LoggingScreen extends ConsumerWidget {
               },
             );
           },
-          loading: () =>
-              const Center(child: ShimmerLoading(width: 40, height: 40)),
+          loading: () => const Center(
+            child: ShimmerLoading(
+              width: 40,
+              height: 40,
+            ),
+          ),
           error: (error, stack) => NoConnectionWidget(
             message: 'We could not load your daily logs. '
                 'This can happen when Supabase tables are missing. '

--- a/lib/features/logging/view/screens/logging_screen.dart
+++ b/lib/features/logging/view/screens/logging_screen.dart
@@ -47,9 +47,8 @@ class LoggingScreen extends ConsumerWidget {
         ],
       ),
       body: RefreshIndicator(
-        onRefresh: () => ref.read(loggingProvider.notifier).loadLogEntries(
-          userId: userId,
-        ),
+        onRefresh: () =>
+            ref.read(loggingProvider.notifier).loadLogEntries(userId: userId),
         child: loggingState.when(
           data: (entries) {
             if (entries.isEmpty) {

--- a/lib/features/logging/view/screens/logging_screen.dart
+++ b/lib/features/logging/view/screens/logging_screen.dart
@@ -47,9 +47,11 @@ class LoggingScreen extends ConsumerWidget {
         ],
       ),
       body: RefreshIndicator(
-        onRefresh: () => ref
-            .read(loggingProvider.notifier)
-            .loadLogEntries(userId: userId),
+        onRefresh: () async {
+          await ref
+              .read(loggingProvider.notifier)
+              .loadLogEntries(userId: userId);
+        },
         child: loggingState.when(
           data: (entries) {
             if (entries.isEmpty) {

--- a/lib/features/logging/view/screens/logging_screen.dart
+++ b/lib/features/logging/view/screens/logging_screen.dart
@@ -47,9 +47,9 @@ class LoggingScreen extends ConsumerWidget {
         ],
       ),
       body: RefreshIndicator(
-        onRefresh: () => ref
-            .read(loggingProvider.notifier)
-            .loadLogEntries(userId: ref.read(authProvider).user?.id),
+        onRefresh: () => ref.read(loggingProvider.notifier).loadLogEntries(
+              userId: ref.read(authProvider).user?.id,
+            ),
         child: loggingState.when(
           data: (entries) {
             if (entries.isEmpty) {
@@ -135,8 +135,9 @@ class LoggingScreen extends ConsumerWidget {
           },
           loading: () =>
               const Center(child: ShimmerLoading(width: 40, height: 40)),
-          error: (error, stack) =>
-              NoConnectionWidget(onRetry: () => ref.refresh(loggingProvider)),
+          error: (error, stack) => NoConnectionWidget(
+            onRetry: () => ref.refresh(loggingProvider),
+          ),
         ),
       ),
       floatingActionButton: FloatingActionButton.extended(

--- a/supabase/migrations/20260422220000_fix_missing_mood_notifications.sql
+++ b/supabase/migrations/20260422220000_fix_missing_mood_notifications.sql
@@ -1,0 +1,103 @@
+-- ============================================================
+-- Fix: Missing mood_comment_notifications table and trigger
+-- ============================================================
+
+-- 1. Create the notifications table if it doesn't exist
+create table if not exists public.mood_comment_notifications (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  mood_pin_id uuid not null references public.mood_pins(id) on delete cascade,
+  comment_id uuid not null references public.mood_pin_comments(id) on delete cascade,
+  comment_text text, -- Nullable as per Issue #84
+  sentiment text,    -- Nullable as per Issue #84
+  is_read boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+-- 2. Add index for performance
+create index if not exists idx_notifications_user on public.mood_comment_notifications(user_id, is_read);
+
+-- 3. Enable RLS
+alter table public.mood_comment_notifications enable row level security;
+
+-- 4. Rebuild policies (drop if exists first)
+drop policy if exists "Users can read own notifications" on public.mood_comment_notifications;
+drop policy if exists "Users can update own notifications" on public.mood_comment_notifications;
+drop policy if exists "Users can delete own notifications" on public.mood_comment_notifications;
+
+create policy "Users can read own notifications"
+  on public.mood_comment_notifications for select
+  using (auth.uid() = user_id);
+
+create policy "Users can update own notifications"
+  on public.mood_comment_notifications for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users can delete own notifications"
+  on public.mood_comment_notifications for delete
+  using (auth.uid() = user_id);
+
+-- 5. Trigger Function to automatically create notifications
+create or replace function public.on_mood_comment_added()
+returns trigger
+language plpgsql
+security definer
+as $$
+declare
+    v_recipient_id uuid;
+    v_sentiment text;
+begin
+    -- Find the owner of the mood pin via the user_mood_pins lookup table
+    select user_id into v_recipient_id
+    from public.user_mood_pins
+    where mood_pin_id = new.mood_pin_id;
+
+    -- Only notify if:
+    -- 1. The owner exists (pins can be truly anonymous if not in user_mood_pins)
+    -- 2. The owner is NOT the person who just commented
+    if v_recipient_id is not null and v_recipient_id != new.user_id then
+        -- Get the sentiment of the pin for the notification preview
+        select sentiment into v_sentiment
+        from public.mood_pins
+        where id = new.mood_pin_id;
+
+        insert into public.mood_comment_notifications (
+            user_id,
+            mood_pin_id,
+            comment_id,
+            comment_text,
+            sentiment,
+            is_read
+        ) values (
+            v_recipient_id,
+            new.mood_pin_id,
+            new.id,
+            new.text,
+            coalesce(v_sentiment, 'neutral'),
+            false
+        );
+    end if;
+    return new;
+end;
+$$;
+
+-- 6. Create the trigger
+drop trigger if exists tr_mood_comment_added on public.mood_pin_comments;
+create trigger tr_mood_comment_added
+  after insert on public.mood_pin_comments
+  for each row execute function public.on_mood_comment_added();
+
+-- 7. Enable Realtime for the notifications table
+-- Check if the table is already in the publication to avoid errors
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables 
+    where pubname = 'supabase_realtime' 
+    and schemaname = 'public' 
+    and tablename = 'mood_comment_notifications'
+  ) then
+    alter publication supabase_realtime add table public.mood_comment_notifications;
+  end if;
+end $$;


### PR DESCRIPTION
## Description
Fixed missing `mood_comment_notifications` table in Supabase that was causing a PGRST205 error, preventing mood comment notifications from loading.

## Changes
- Added migration to create the `mood_comment_notifications` table in the public schema
- Ensures the table is available in the Supabase schema cache on load

## Steps Tested
- Ran the app with valid Supabase credentials
- Navigated to the Global Mirror and Socials tab
- Confirmed notification bell loads correctly with no console errors

## Related Issue
Closes #191 
