### PR TITLE
fix(#208): prevent notification plugin failure from breaking createLo…

### DIFF
--- a/lib/features/logging/viewmodel/providers/logging_provider.dart
+++ b/lib/features/logging/viewmodel/providers/logging_provider.dart
@@ -65,9 +65,13 @@ class LoggingNotifier extends StateNotifier<AsyncValue<List<LogEntryModel>>> {
       final currentData = state.value ?? [];
       state = AsyncValue.data([...currentData, created]);
 
-      // Cancel no-log-today notification since user has logged
-      final notificationService = NotificationService();
-      await notificationService.cancelNoLogTodayNotification();
+      // Wrap notification call so platform plugin failures (e.g. MissingPluginException
+      // in unit tests) do not fail the entire log entry creation.
+      try {
+        await NotificationService().cancelNoLogTodayNotification();
+      } catch (_) {
+        // Ignore notification errors (e.g., in unit tests where plugins are unavailable)
+      }
 
       return true;
     } catch (e) {

--- a/test/features/logging/logging_provider_test.dart
+++ b/test/features/logging/logging_provider_test.dart
@@ -25,6 +25,11 @@ LogEntryModel _makeEntry({
 }
 
 void main() {
+  // Register fallback value for LogEntryModel to avoid mocktail errors
+  setUpAll(() {
+    registerFallbackValue(_makeEntry());
+  });
+
   group('LoggingNotifier', () {
     late MockLoggingRepository mockRepo;
     late LoggingNotifier notifier;


### PR DESCRIPTION
Closes #208

---

This PR fixes an issue where createLogEntry returned false in unit tests due to a platform plugin failure.

The NotificationService call was triggering a MissingPluginException in test environments, causing the catch block to return false even when the repository call succeeded.

Fix:
- Wrapped NotificationService().cancelNoLogTodayNotification() in a try/catch block to isolate side-effect failures.

Additionally:
- Added registerFallbackValue for LogEntryModel in tests to resolve mocktail matcher errors.

Result:
- All tests pass successfully
- Core logic is no longer affected by platform-specific failures
