### PR TITLE
feat(web): mood analytics page — charts for mood trends, habit frequency, streak calendar

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.2",
+        "recharts": "^3.8.1",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -86,6 +87,42 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -352,6 +389,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.104.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.1.tgz",
@@ -475,6 +524,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -503,6 +615,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -644,6 +762,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -664,6 +791,133 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -681,6 +935,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -690,6 +954,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -745,6 +1015,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lightningcss": {
@@ -1111,6 +1400,36 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.14.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
@@ -1148,6 +1467,57 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
@@ -1217,6 +1587,12 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -1291,6 +1667,37 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.2",
+    "recharts": "^3.8.1",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -7,6 +7,7 @@ import { LogsListPage } from '../features/logs/logs-list-page'
 import { LogFormPage } from '../features/logs/log-form-page'
 import { InsightsPage } from '../features/insights/insights-page'
 import { PlaceholderPage } from '../features/shared/placeholder-page'
+import { AnalyticsPage } from '../features/analytics/analytics-page'
 
 function RequireAuth() {
   const { user, isLoading } = useAuth()
@@ -45,15 +46,7 @@ export function AppRouter() {
         <Route path="/logs/new" element={<LogFormPage mode="create" />} />
         <Route path="/logs/:id/edit" element={<LogFormPage mode="edit" />} />
         <Route path="/insights" element={<InsightsPage />} />
-        <Route
-          path="/analytics"
-          element={
-            <PlaceholderPage
-              title="Analytics"
-              description="Trend charts and engagement metrics will appear here."
-            />
-          }
-        />
+        <Route path="/analytics" element={<AnalyticsPage />} />
         <Route
           path="/global-mirror"
           element={

--- a/frontend/src/features/analytics/analytics-page.tsx
+++ b/frontend/src/features/analytics/analytics-page.tsx
@@ -1,0 +1,490 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../lib/auth-context'
+import { toDateInputValue } from '../../lib/date'
+import type { LogEntry } from '../../lib/types'
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+type Range = '7' | '30' | '90' | '365' | 'all'
+
+const RANGE_OPTIONS: { label: string; value: Range }[] = [
+  { label: 'Last 7 days', value: '7' },
+  { label: 'Last 30 days', value: '30' },
+  { label: 'Last 90 days', value: '90' },
+  { label: 'Last 365 days', value: '365' },
+  { label: 'All time', value: 'all' },
+]
+
+// Mood 1–5 → green shades; no log → grey
+const MOOD_COLORS: Record<number, string> = {
+  1: '#bbf7d0',
+  2: '#86efac',
+  3: '#4ade80',
+  4: '#22c55e',
+  5: '#16a34a',
+}
+const NO_LOG_COLOR = '#e5e7eb'
+
+const MOOD_LABELS: Record<number, string> = {
+  1: '😞 Very Low',
+  2: '😕 Low',
+  3: '😐 Neutral',
+  4: '🙂 Good',
+  5: '😄 Great',
+}
+
+const PIE_COLORS = ['#bbf7d0', '#86efac', '#4ade80', '#22c55e', '#16a34a']
+
+// ── Data fetching ─────────────────────────────────────────────────────────
+
+async function fetchAnalyticsLogs(userId: string, days: number | null): Promise<LogEntry[]> {
+  let query = supabase
+    .from('log_entries')
+    .select('*')
+    .eq('user_id', userId)
+    .order('date', { ascending: true })
+
+  if (days !== null) {
+    const since = new Date()
+    since.setDate(since.getDate() - days)
+    query = query.gte('date', since.toISOString())
+  }
+
+  const { data, error } = await query
+  if (error) throw error
+  return ((data ?? []) as LogEntry[]).map((e) => ({
+    ...e,
+    habits: Array.isArray(e.habits) ? e.habits : [],
+  }))
+}
+
+// ── Analytics computations ────────────────────────────────────────────────
+
+function dateKey(isoString: string): string {
+  return isoString.slice(0, 10)
+}
+
+function computeStats(logs: LogEntry[]) {
+  const uniqueDates = [...new Set(logs.map((l) => dateKey(l.date)))].sort()
+  const dateSet = new Set(uniqueDates)
+
+  // Current streak (consecutive days ending today or yesterday)
+  let currentStreak = 0
+  const cursor = new Date()
+  while (dateSet.has(toDateInputValue(cursor))) {
+    currentStreak++
+    cursor.setDate(cursor.getDate() - 1)
+  }
+
+  // Longest streak
+  let longestStreak = uniqueDates.length > 0 ? 1 : 0
+  let run = uniqueDates.length > 0 ? 1 : 0
+  for (let i = 1; i < uniqueDates.length; i++) {
+    const prev = new Date(uniqueDates[i - 1])
+    const curr = new Date(uniqueDates[i])
+    const diffDays = Math.round((curr.getTime() - prev.getTime()) / 86_400_000)
+    if (diffDays === 1) {
+      run++
+      if (run > longestStreak) longestStreak = run
+    } else {
+      run = 1
+    }
+  }
+
+  // Most logged habit
+  const habitCounts: Record<string, number> = {}
+  for (const log of logs) {
+    for (const habit of log.habits) {
+      habitCounts[habit] = (habitCounts[habit] ?? 0) + 1
+    }
+  }
+  const mostLoggedHabit =
+    Object.entries(habitCounts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '—'
+
+  return { currentStreak, longestStreak, totalLogDays: uniqueDates.length, mostLoggedHabit }
+}
+
+function buildMoodOverTime(logs: LogEntry[]) {
+  return logs
+    .filter((l) => l.mood !== null)
+    .map((l) => ({ date: dateKey(l.date), mood: l.mood as number }))
+}
+
+function buildHabitFrequency(logs: LogEntry[]) {
+  const counts: Record<string, number> = {}
+  for (const log of logs) {
+    for (const habit of log.habits) {
+      counts[habit] = (counts[habit] ?? 0) + 1
+    }
+  }
+  return Object.entries(counts)
+    .map(([habit, count]) => ({ habit, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 15)
+}
+
+function buildMoodDistribution(logs: LogEntry[]) {
+  const counts: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+  for (const log of logs) {
+    if (log.mood !== null && log.mood >= 1 && log.mood <= 5) {
+      counts[log.mood]++
+    }
+  }
+  return [1, 2, 3, 4, 5]
+    .filter((m) => counts[m] > 0)
+    .map((m) => ({ name: MOOD_LABELS[m], value: counts[m], mood: m }))
+}
+
+function buildLogConsistency(logs: LogEntry[]) {
+  let total = 0
+  return logs.map((l) => ({ date: dateKey(l.date), total: ++total }))
+}
+
+// ── Streak Calendar ───────────────────────────────────────────────────────
+
+function buildCalendarGrid(logs: LogEntry[], days: number | null) {
+  const moodByDate: Record<string, number> = {}
+  for (const log of logs) {
+    if (log.mood !== null) moodByDate[dateKey(log.date)] = log.mood
+    else if (!moodByDate[dateKey(log.date)]) moodByDate[dateKey(log.date)] = 0
+  }
+
+  const totalDays = days ?? 365
+  const end = new Date()
+  const start = new Date()
+  start.setDate(end.getDate() - totalDays + 1)
+
+  // Align start to Monday
+  const dayOfWeek = start.getDay()
+  const offset = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+  start.setDate(start.getDate() - offset)
+
+  const cells: { date: string; mood: number | null }[] = []
+  const cur = new Date(start)
+  while (cur <= end) {
+    const key = toDateInputValue(cur)
+    cells.push({ date: key, mood: moodByDate[key] !== undefined ? moodByDate[key] : null })
+    cur.setDate(cur.getDate() + 1)
+  }
+
+  // Group into weeks (each week = 7 days Mon–Sun)
+  const weeks: { date: string; mood: number | null }[][] = []
+  for (let i = 0; i < cells.length; i += 7) {
+    weeks.push(cells.slice(i, i + 7))
+  }
+  return weeks
+}
+
+// ── Tooltip formatters ────────────────────────────────────────────────────
+
+function MoodTooltip({ active, payload, label }: { active?: boolean; payload?: { value: number }[]; label?: string }) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="analytics-tooltip">
+      <p className="analytics-tooltip-date">{label}</p>
+      <p>Mood: <strong>{payload[0].value} / 5</strong></p>
+    </div>
+  )
+}
+
+function HabitTooltip({ active, payload, label }: { active?: boolean; payload?: { value: number }[]; label?: string }) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="analytics-tooltip">
+      <p className="analytics-tooltip-date">{label}</p>
+      <p>Days logged: <strong>{payload[0].value}</strong></p>
+    </div>
+  )
+}
+
+function ConsistencyTooltip({ active, payload, label }: { active?: boolean; payload?: { value: number }[]; label?: string }) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="analytics-tooltip">
+      <p className="analytics-tooltip-date">{label}</p>
+      <p>Total logs: <strong>{payload[0].value}</strong></p>
+    </div>
+  )
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────
+
+export function AnalyticsPage() {
+  const { user } = useAuth()
+  const [range, setRange] = useState<Range>('30')
+
+  const days = range === 'all' ? null : parseInt(range, 10)
+
+  const logsQuery = useQuery({
+    queryKey: ['analytics-logs', user?.id, range],
+    queryFn: () => fetchAnalyticsLogs(user!.id, days),
+    enabled: Boolean(user?.id),
+  })
+
+  const logs = logsQuery.data ?? []
+  const isEmpty = !logsQuery.isLoading && logs.length < 3
+
+  const stats = useMemo(() => computeStats(logs), [logs])
+  const moodOverTime = useMemo(() => buildMoodOverTime(logs), [logs])
+  const habitFrequency = useMemo(() => buildHabitFrequency(logs), [logs])
+  const moodDistribution = useMemo(() => buildMoodDistribution(logs), [logs])
+  const logConsistency = useMemo(() => buildLogConsistency(logs), [logs])
+  const calendarWeeks = useMemo(() => buildCalendarGrid(logs, days), [logs, days])
+
+  if (!user) return null
+
+  return (
+    <section className="analytics-page">
+      {/* ── Header + range filter ── */}
+      <div className="analytics-header">
+        <div>
+          <h2>Analytics</h2>
+          <p className="muted">Visualise your mood trends, habits, and consistency.</p>
+        </div>
+        <div className="analytics-range-tabs" role="group" aria-label="Date range">
+          {RANGE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={`analytics-range-btn${range === opt.value ? ' active' : ''}`}
+              onClick={() => setRange(opt.value)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Loading ── */}
+      {logsQuery.isLoading ? (
+        <div className="analytics-loading">
+          <div className="skeleton-line" />
+          <div className="skeleton-line" />
+          <div className="skeleton-line" />
+        </div>
+      ) : isEmpty ? (
+        /* ── Empty state ── */
+        <div className="analytics-empty">
+          <span className="analytics-empty-icon">📊</span>
+          <h3>Not enough data yet</h3>
+          <p className="muted">Log at least 3 entries to unlock your analytics dashboard.</p>
+          <a href="/logs/new" className="analytics-cta-link">Start logging →</a>
+        </div>
+      ) : (
+        <>
+          {/* ── Stats summary row ── */}
+          <div className="analytics-stats-row">
+            <div className="analytics-stat-card">
+              <span className="analytics-stat-icon">🔥</span>
+              <p className="analytics-stat-value">{stats.currentStreak}</p>
+              <p className="analytics-stat-label">Current streak</p>
+            </div>
+            <div className="analytics-stat-card">
+              <span className="analytics-stat-icon">🏆</span>
+              <p className="analytics-stat-value">{stats.longestStreak}</p>
+              <p className="analytics-stat-label">Longest streak</p>
+            </div>
+            <div className="analytics-stat-card">
+              <span className="analytics-stat-icon">📅</span>
+              <p className="analytics-stat-value">{stats.totalLogDays}</p>
+              <p className="analytics-stat-label">Total log days</p>
+            </div>
+            <div className="analytics-stat-card">
+              <span className="analytics-stat-icon">⭐</span>
+              <p className="analytics-stat-value analytics-stat-value--sm">{stats.mostLoggedHabit}</p>
+              <p className="analytics-stat-label">Top habit</p>
+            </div>
+          </div>
+
+          {/* ── Charts grid ── */}
+          <div className="analytics-charts-grid">
+
+            {/* 1. Mood over time */}
+            <div className="card analytics-chart-card full-width">
+              <h3>Mood over time</h3>
+              <div className="analytics-chart-scroll">
+                <div style={{ minWidth: Math.max(500, moodOverTime.length * 18) }}>
+                  <ResponsiveContainer width="100%" height={220}>
+                    <LineChart data={moodOverTime} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--line)" />
+                      <XAxis dataKey="date" tick={{ fontSize: 11 }} tickLine={false} interval="preserveStartEnd" />
+                      <YAxis domain={[1, 5]} ticks={[1, 2, 3, 4, 5]} tick={{ fontSize: 11 }} tickLine={false} />
+                      <Tooltip content={<MoodTooltip />} />
+                      <Line
+                        type="monotone"
+                        dataKey="mood"
+                        stroke="var(--brand)"
+                        strokeWidth={2}
+                        dot={{ r: 3, fill: 'var(--brand)' }}
+                        activeDot={{ r: 5 }}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+            </div>
+
+            {/* 2. Habit frequency */}
+            <div className="card analytics-chart-card">
+              <h3>Habit frequency</h3>
+              <div className="analytics-chart-scroll">
+                <div style={{ minWidth: Math.max(360, habitFrequency.length * 48) }}>
+                  <ResponsiveContainer width="100%" height={220}>
+                    <BarChart data={habitFrequency} margin={{ top: 8, right: 16, left: 0, bottom: 40 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--line)" vertical={false} />
+                      <XAxis
+                        dataKey="habit"
+                        tick={{ fontSize: 11 }}
+                        tickLine={false}
+                        angle={-35}
+                        textAnchor="end"
+                        interval={0}
+                      />
+                      <YAxis allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} />
+                      <Tooltip content={<HabitTooltip />} />
+                      <Bar dataKey="count" fill="var(--brand)" radius={[4, 4, 0, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+            </div>
+
+            {/* 3. Mood distribution */}
+            <div className="card analytics-chart-card">
+              <h3>Mood distribution</h3>
+              <ResponsiveContainer width="100%" height={220}>
+                <PieChart>
+                  <Pie
+                    data={moodDistribution}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={80}
+                    label={({ name, percent }) =>
+                      `${name} (${Math.round((percent ?? 0) * 100)}%)`
+                    }
+                    labelLine={false}
+                  >
+                    {moodDistribution.map((entry) => (
+                      <Cell key={entry.mood} fill={PIE_COLORS[entry.mood - 1]} />
+                    ))}
+                  </Pie>
+                  <Tooltip formatter={(value) => [`${value} days`, 'Count']} />
+                  <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* 4. Log consistency */}
+            <div className="card analytics-chart-card full-width">
+              <h3>Log consistency (cumulative)</h3>
+              <div className="analytics-chart-scroll">
+                <div style={{ minWidth: Math.max(500, logConsistency.length * 18) }}>
+                  <ResponsiveContainer width="100%" height={200}>
+                    <AreaChart data={logConsistency} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                      <defs>
+                        <linearGradient id="consistencyGrad" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="5%" stopColor="var(--brand)" stopOpacity={0.25} />
+                          <stop offset="95%" stopColor="var(--brand)" stopOpacity={0} />
+                        </linearGradient>
+                      </defs>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--line)" />
+                      <XAxis dataKey="date" tick={{ fontSize: 11 }} tickLine={false} interval="preserveStartEnd" />
+                      <YAxis allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} />
+                      <Tooltip content={<ConsistencyTooltip />} />
+                      <Area
+                        type="monotone"
+                        dataKey="total"
+                        stroke="var(--brand)"
+                        strokeWidth={2}
+                        fill="url(#consistencyGrad)"
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+            </div>
+
+            {/* 5. Streak calendar */}
+            <div className="card analytics-chart-card full-width">
+              <h3>Streak calendar</h3>
+              <div className="analytics-calendar-legend">
+                <span className="muted" style={{ fontSize: '0.75rem' }}>Less</span>
+                <span className="calendar-cell" style={{ background: NO_LOG_COLOR }} title="No log" />
+                {[1, 2, 3, 4, 5].map((m) => (
+                  <span
+                    key={m}
+                    className="calendar-cell"
+                    style={{ background: MOOD_COLORS[m] }}
+                    title={MOOD_LABELS[m]}
+                  />
+                ))}
+                <span className="muted" style={{ fontSize: '0.75rem' }}>More</span>
+              </div>
+              <div className="analytics-chart-scroll">
+                <div className="calendar-grid">
+                  {/* Day labels column */}
+                  <div className="calendar-day-labels">
+                    {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map((d) => (
+                      <span key={d} className="calendar-day-label">{d}</span>
+                    ))}
+                  </div>
+
+                  {/* Week columns */}
+                  {calendarWeeks.map((week, wi) => (
+                    <div key={wi} className="calendar-week">
+                      {week.map((cell, di) => (
+                        <div
+                          key={di}
+                          className="calendar-cell"
+                          style={{
+                            background:
+                              cell.mood === null
+                                ? NO_LOG_COLOR
+                                : cell.mood === 0
+                                  ? '#d1fae5'
+                                  : MOOD_COLORS[cell.mood],
+                          }}
+                          title={
+                            cell.mood === null
+                              ? `${cell.date}: no log`
+                              : `${cell.date}: mood ${cell.mood}`
+                          }
+                          aria-label={
+                            cell.mood === null
+                              ? `${cell.date}: no log`
+                              : `${cell.date}: mood ${cell.mood}`
+                          }
+                        />
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -754,3 +754,239 @@ td {
     min-width: 120px;
   }
 }
+
+/* ── Analytics page ──────────────────────────────────────────────────────── */
+.analytics-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.analytics-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.analytics-header h2 {
+  margin: 0 0 0.25rem;
+}
+
+.analytics-range-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.analytics-range-btn {
+  background: var(--surface-soft);
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.analytics-range-btn:hover {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+
+.analytics-range-btn.active {
+  background: var(--brand);
+  color: #fff;
+  border-color: var(--brand);
+}
+
+/* Stats summary */
+.analytics-stats-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+}
+
+.analytics-stat-card {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 1.2rem 1rem;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.analytics-stat-icon {
+  font-size: 1.5rem;
+}
+
+.analytics-stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  font-family: 'Fraunces', serif;
+  color: var(--brand);
+  margin: 0.25rem 0 0.1rem;
+  line-height: 1.1;
+}
+
+.analytics-stat-value--sm {
+  font-size: 1.1rem;
+  word-break: break-word;
+}
+
+.analytics-stat-label {
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+/* Charts grid */
+.analytics-charts-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.analytics-chart-card {
+  padding: 1.25rem;
+  overflow: hidden;
+}
+
+.analytics-chart-card h3 {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+}
+
+/* Horizontal scroll for wide charts */
+.analytics-chart-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 4px;
+}
+
+/* Tooltip */
+.analytics-tooltip {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.6rem 0.9rem;
+  font-size: 0.85rem;
+  box-shadow: var(--shadow);
+}
+
+.analytics-tooltip-date {
+  color: var(--muted);
+  font-size: 0.78rem;
+  margin: 0 0 0.3rem;
+}
+
+/* Loading */
+.analytics-loading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 2rem 0;
+}
+
+/* Empty state */
+.analytics-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.analytics-empty-icon {
+  font-size: 3rem;
+}
+
+.analytics-empty h3 {
+  margin: 0;
+}
+
+.analytics-cta-link {
+  color: var(--brand);
+  font-weight: 600;
+  text-decoration: none;
+  padding: 0.5rem 1.25rem;
+  border: 1.5px solid var(--brand);
+  border-radius: 10px;
+  transition: all 0.15s ease;
+}
+
+.analytics-cta-link:hover {
+  background: var(--brand);
+  color: #fff;
+}
+
+/* Streak calendar */
+.analytics-calendar-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 0.75rem;
+}
+
+.calendar-grid {
+  display: flex;
+  gap: 3px;
+  min-width: max-content;
+}
+
+.calendar-day-labels {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding-top: 2px;
+  margin-right: 2px;
+}
+
+.calendar-day-label {
+  font-size: 0.65rem;
+  color: var(--muted);
+  height: 14px;
+  line-height: 14px;
+  width: 24px;
+}
+
+.calendar-week {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.calendar-cell {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  display: inline-block;
+  transition: transform 0.1s ease;
+}
+
+.calendar-cell:hover {
+  transform: scale(1.4);
+  z-index: 1;
+}
+
+@media (max-width: 768px) {
+  .analytics-stats-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .analytics-charts-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .analytics-header {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the `/analytics` page requested in #227. All 5 chart types, date range filter, stats summary row, empty state, tooltips, and responsive layout.

## Changes

### New: `frontend/src/features/analytics/analytics-page.tsx`

**Stats row** (above charts):
| Stat | Source |
|------|--------|
| Current streak | Consecutive days with a log ending today |
| Longest streak | Max run of consecutive logged days |
| Total log days | Unique dates in selected range |
| Top habit | Most-logged habit in selected range |

**Charts (all Recharts, all reactive to date range):**

| # | Type | Description |
|---|------|-------------|
| 1 | `LineChart` | Mood over time — daily mood 1–5 |
| 2 | `BarChart` | Habit frequency — count of days each habit appeared |
| 3 | `PieChart` | Mood distribution — % of days at each mood level |
| 4 | `AreaChart` | Log consistency — cumulative log count |
| 5 | Custom grid | Streak calendar — GitHub-style heatmap; grey=no log, 5 green shades=mood 1–5 |

**Date range filter:** Last 7 / 30 / 90 / 365 / All time — all charts refetch via TanStack Query on change.

**Empty state:** shown with a "Start logging" CTA when fewer than 3 entries exist.

**Responsive:** 2-column chart grid on desktop, 1-column on mobile. Wide charts scroll horizontally on small screens.

**Tooltips:** all charts show exact value + date on hover.

### Updated: `frontend/src/app/router.tsx`
- Replaced `PlaceholderPage` at `/analytics` with `<AnalyticsPage />`

### Updated: `frontend/src/styles.css`
- Added all analytics layout and component styles (`.analytics-page`, `.analytics-stats-row`, `.calendar-grid`, `.analytics-chart-scroll`, etc.)

### Updated: `frontend/package.json`
- Added `recharts` dependency

## Acceptance criteria

- [x] All 5 chart types render with real data from `log_entries`
- [x] Empty state shown with a prompt to log more when fewer than 3 entries exist
- [x] Date range filter updates all charts simultaneously
- [x] Charts are responsive (horizontal scroll on small screens)
- [x] Tooltips on hover show the exact value and date
- [x] Streak calendar colours: grey = no log, green shades = mood 1–5

Closes #227