### PR TITLE
feat: analytics page, global mirror map, notification drawer, dark mode

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.2",
+        "recharts": "^2.15.0",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -25,27 +26,13 @@
         "vite": "^8.0.10"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -475,6 +462,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -490,6 +540,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -609,6 +660,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -644,6 +696,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -661,7 +722,133 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -672,6 +859,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -689,6 +886,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/fdir": {
@@ -746,6 +958,21 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1008,6 +1235,24 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1034,6 +1279,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1047,6 +1301,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1074,6 +1329,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1090,11 +1346,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1104,12 +1378,19 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-router": {
       "version": "7.14.2",
@@ -1147,6 +1428,69 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/rolldown": {
@@ -1217,6 +1561,12 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -1293,12 +1643,35 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.10",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.2",
+    "recharts": "^2.15.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -6,6 +6,8 @@ import { WalletPage } from '../features/wallet/wallet-page'
 import { LogsListPage } from '../features/logs/logs-list-page'
 import { LogFormPage } from '../features/logs/log-form-page'
 import { InsightsPage } from '../features/insights/insights-page'
+import { AnalyticsPage } from '../features/analytics/analytics-page'
+import { GlobalMirrorPage } from '../features/global-mirror/global-mirror-page'
 import { PlaceholderPage } from '../features/shared/placeholder-page'
 
 function RequireAuth() {
@@ -45,24 +47,8 @@ export function AppRouter() {
         <Route path="/logs/new" element={<LogFormPage mode="create" />} />
         <Route path="/logs/:id/edit" element={<LogFormPage mode="edit" />} />
         <Route path="/insights" element={<InsightsPage />} />
-        <Route
-          path="/analytics"
-          element={
-            <PlaceholderPage
-              title="Analytics"
-              description="Trend charts and engagement metrics will appear here."
-            />
-          }
-        />
-        <Route
-          path="/global-mirror"
-          element={
-            <PlaceholderPage
-              title="Global Mirror"
-              description="Community mirror feed and world mood layers are coming next."
-            />
-          }
-        />
+        <Route path="/analytics" element={<AnalyticsPage />} />
+        <Route path="/global-mirror" element={<GlobalMirrorPage />} />
         <Route
           path="/settings"
           element={

--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -3,6 +3,7 @@ import { NavLink, Outlet, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '../../lib/auth-context'
 import { supabase } from '../../lib/supabase'
+import { NotificationDrawer } from '../../features/notifications/notification-drawer'
 
 const navItems = [
   { icon: '🏠', to: '/dashboard', label: 'Dashboard' },
@@ -34,6 +35,7 @@ export function AppShell() {
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [isMobileDrawerOpen, setIsMobileDrawerOpen] = useState(false)
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false)
+  const [isNotificationPanelOpen, setIsNotificationPanelOpen] = useState(false)
 
   const unreadNotificationsQuery = useQuery({
     queryKey: ['unread-notifications', user?.id],
@@ -140,12 +142,24 @@ export function AppShell() {
           </label>
 
           <div className="shell-topbar-actions">
-            <button type="button" className="icon-btn notification-btn" aria-label="Notifications">
-              🔔
-              {(unreadNotificationsQuery.data ?? 0) > 0 ? (
-                <span className="badge">{unreadNotificationsQuery.data}</span>
-              ) : null}
-            </button>
+            <div style={{ position: 'relative' }}>
+              <button
+                type="button"
+                className="icon-btn notification-btn"
+                aria-label="Notifications"
+                aria-expanded={isNotificationPanelOpen}
+                onClick={() => setIsNotificationPanelOpen((prev) => !prev)}
+              >
+                🔔
+                {(unreadNotificationsQuery.data ?? 0) > 0 ? (
+                  <span className="badge">{unreadNotificationsQuery.data}</span>
+                ) : null}
+              </button>
+              <NotificationDrawer
+                isOpen={isNotificationPanelOpen}
+                onClose={() => setIsNotificationPanelOpen(false)}
+              />
+            </div>
 
             <div className="avatar-menu-wrap">
               <button

--- a/frontend/src/features/analytics/analytics-page.tsx
+++ b/frontend/src/features/analytics/analytics-page.tsx
@@ -1,0 +1,207 @@
+/**
+ * Analytics Page  (#259)
+ *
+ * Sections:
+ * 1. Mood trend line chart (daily mood score over 30 days)
+ * 2. Habit frequency bar chart (top 8 habits over 30 days)
+ * 3. Streak calendar (12-week grid)
+ */
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  LineChart, Line, BarChart, Bar,
+  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from 'recharts'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../lib/auth-context'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type LogEntry = {
+  id: string
+  date: string
+  mood_score: number
+  habits: string[] | null
+}
+
+// ── Data helpers ──────────────────────────────────────────────────────────────
+
+function thirtyDaysAgo(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 30)
+  return d.toISOString().slice(0, 10)
+}
+
+async function fetchEntries(userId: string): Promise<LogEntry[]> {
+  const { data, error } = await supabase
+    .from('log_entries')
+    .select('id, date, mood_score, habits')
+    .eq('user_id', userId)
+    .gte('date', thirtyDaysAgo())
+    .order('date', { ascending: true })
+
+  if (error) throw error
+  return (data ?? []) as LogEntry[]
+}
+
+function buildMoodTrend(entries: LogEntry[]): { date: string; mood: number }[] {
+  return entries
+    .filter((e) => e.mood_score != null)
+    .map((e) => ({ date: e.date.slice(5), mood: e.mood_score }))
+}
+
+function buildHabitFrequency(entries: LogEntry[]): { habit: string; count: number }[] {
+  const freq: Record<string, number> = {}
+  for (const e of entries) {
+    for (const h of e.habits ?? []) {
+      freq[h] = (freq[h] ?? 0) + 1
+    }
+  }
+  return Object.entries(freq)
+    .map(([habit, count]) => ({ habit, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 8)
+}
+
+function buildStreakDays(entries: LogEntry[]): Set<string> {
+  return new Set(entries.map((e) => e.date.slice(0, 10)))
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function StreakCalendar({ loggedDays }: { loggedDays: Set<string> }) {
+  const cells = useMemo(() => {
+    const today = new Date()
+    const out: { dateStr: string; logged: boolean }[] = []
+    for (let i = 83; i >= 0; i--) {
+      const d = new Date(today)
+      d.setDate(today.getDate() - i)
+      const dateStr = d.toISOString().slice(0, 10)
+      out.push({ dateStr, logged: loggedDays.has(dateStr) })
+    }
+    return out
+  }, [loggedDays])
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(12, 1fr)',
+        gap: '3px',
+      }}
+    >
+      {cells.map(({ dateStr, logged }) => (
+        <div
+          key={dateStr}
+          title={dateStr}
+          style={{
+            aspectRatio: '1',
+            borderRadius: '3px',
+            background: logged ? 'var(--brand)' : 'var(--line)',
+            opacity: logged ? 1 : 0.5,
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+function Skeleton() {
+  return (
+    <div className="card animate-stagger">
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          style={{
+            height: '200px',
+            background: 'var(--line)',
+            borderRadius: '12px',
+            marginBottom: '1rem',
+            animation: 'pulse 1.5s ease-in-out infinite',
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export function AnalyticsPage() {
+  const { user } = useAuth()
+
+  const query = useQuery({
+    queryKey: ['analytics-entries', user?.id],
+    queryFn: () => fetchEntries(user!.id),
+    enabled: Boolean(user?.id),
+  })
+
+  if (query.isLoading) return <Skeleton />
+  if (query.isError) {
+    return (
+      <section className="card full-width">
+        <p className="muted">Failed to load analytics data. Please try again.</p>
+      </section>
+    )
+  }
+
+  const entries = query.data ?? []
+
+  if (entries.length === 0) {
+    return (
+      <section className="card full-width placeholder-page">
+        <h2>Analytics</h2>
+        <p className="muted">No log entries found for the past 30 days. Start logging to see your trends here.</p>
+      </section>
+    )
+  }
+
+  const moodTrend = buildMoodTrend(entries)
+  const habitFreq = buildHabitFrequency(entries)
+  const loggedDays = buildStreakDays(entries)
+
+  return (
+    <div className="page-wrap animate-stagger" style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      <h1>Analytics</h1>
+
+      {/* Mood trend */}
+      <section className="card">
+        <h2 style={{ marginTop: 0 }}>Mood Trend — last 30 days</h2>
+        <ResponsiveContainer width="100%" height={220}>
+          <LineChart data={moodTrend}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--line)" />
+            <XAxis dataKey="date" tick={{ fontSize: 11, fill: 'var(--muted)' }} />
+            <YAxis domain={[1, 5]} ticks={[1, 2, 3, 4, 5]} tick={{ fontSize: 11, fill: 'var(--muted)' }} />
+            <Tooltip contentStyle={{ background: 'var(--surface)', border: '1px solid var(--line)', borderRadius: '8px' }} />
+            <Line type="monotone" dataKey="mood" stroke="var(--brand)" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </section>
+
+      {/* Habit frequency */}
+      {habitFreq.length > 0 && (
+        <section className="card">
+          <h2 style={{ marginTop: 0 }}>Top Habits — last 30 days</h2>
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={habitFreq} layout="vertical">
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--line)" />
+              <XAxis type="number" tick={{ fontSize: 11, fill: 'var(--muted)' }} />
+              <YAxis type="category" dataKey="habit" width={110} tick={{ fontSize: 11, fill: 'var(--muted)' }} />
+              <Tooltip contentStyle={{ background: 'var(--surface)', border: '1px solid var(--line)', borderRadius: '8px' }} />
+              <Bar dataKey="count" fill="var(--brand)" radius={[0, 4, 4, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </section>
+      )}
+
+      {/* Streak calendar */}
+      <section className="card">
+        <h2 style={{ marginTop: 0 }}>Logging Streak — last 12 weeks</h2>
+        <StreakCalendar loggedDays={loggedDays} />
+        <p className="muted" style={{ marginTop: '0.5rem', fontSize: '0.8rem' }}>
+          {loggedDays.size} day{loggedDays.size !== 1 ? 's' : ''} logged in the past 12 weeks
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/features/global-mirror/global-mirror-page.tsx
+++ b/frontend/src/features/global-mirror/global-mirror-page.tsx
@@ -1,0 +1,293 @@
+/**
+ * Global Mirror Page  (#260)
+ *
+ * Sections:
+ * 1. Live SVG world map with real-time mood pins from Supabase Realtime
+ * 2. Drop-a-pin panel (sentiment selector + geolocation)
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type { RealtimeChannel } from '@supabase/supabase-js'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../lib/auth-context'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type MoodPin = {
+  id: string
+  grid_lat: number
+  grid_lon: number
+  sentiment: string
+  created_at: string
+  comment?: string
+}
+
+type Sentiment = 'happy' | 'sad' | 'stressed' | 'calm' | 'anxious'
+
+const SENTIMENTS: { value: Sentiment; label: string; emoji: string; color: string }[] = [
+  { value: 'happy',    label: 'Happy',    emoji: '😊', color: '#22c55e' },
+  { value: 'sad',      label: 'Sad',      emoji: '😔', color: '#60a5fa' },
+  { value: 'stressed', label: 'Stressed', emoji: '😤', color: '#f97316' },
+  { value: 'calm',     label: 'Calm',     emoji: '😌', color: '#818cf8' },
+  { value: 'anxious',  label: 'Anxious',  emoji: '😰', color: '#f43f5e' },
+]
+
+const SENTIMENT_COLOR: Record<string, string> = Object.fromEntries(
+  SENTIMENTS.map((s) => [s.value, s.color]),
+)
+
+// ── Coordinate helpers (match mobile MoodPinModel.anonymizeCoordinate) ─────────
+
+function anonymize(coord: number): number {
+  return Math.round(coord * 10) / 10
+}
+
+// Map geographic lon/lat to SVG x/y (simple equirectangular)
+function toSvgCoord(lat: number, lon: number): { x: number; y: number } {
+  const x = ((lon + 180) / 360) * 800
+  const y = ((90 - lat) / 180) * 400
+  return { x, y }
+}
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+
+async function fetchPins(): Promise<MoodPin[]> {
+  const { data, error } = await supabase
+    .from('mood_pins')
+    .select('id, grid_lat, grid_lon, sentiment, created_at')
+    .order('created_at', { ascending: false })
+    .limit(500)
+  if (error) throw error
+  return (data ?? []) as MoodPin[]
+}
+
+async function insertPin(
+  userId: string,
+  lat: number,
+  lon: number,
+  sentiment: Sentiment,
+): Promise<void> {
+  const { error } = await supabase.from('mood_pins').insert({
+    user_id: userId,
+    grid_lat: anonymize(lat),
+    grid_lon: anonymize(lon),
+    sentiment,
+  })
+  if (error) throw error
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function PinPopover({
+  pin,
+  x,
+  y,
+  onClose,
+}: {
+  pin: MoodPin
+  x: number
+  y: number
+  onClose: () => void
+}) {
+  const [comment, setComment] = useState('')
+  const sentiment = SENTIMENTS.find((s) => s.value === pin.sentiment)
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: x,
+        top: y,
+        transform: 'translate(-50%, -110%)',
+        background: 'var(--surface)',
+        border: '1px solid var(--line)',
+        borderRadius: '10px',
+        padding: '0.75rem 1rem',
+        boxShadow: 'var(--shadow)',
+        zIndex: 10,
+        width: '200px',
+        fontSize: '0.82rem',
+      }}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        style={{ position: 'absolute', top: 6, right: 8, background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)' }}
+      >
+        ✕
+      </button>
+      <p style={{ margin: '0 0 4px', fontWeight: 600, color: 'var(--text)' }}>
+        {sentiment?.emoji} {sentiment?.label ?? pin.sentiment}
+      </p>
+      <p style={{ margin: '0 0 8px', color: 'var(--muted)' }}>
+        {pin.created_at.slice(0, 10)}
+      </p>
+      <textarea
+        placeholder="Add a comment…"
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        rows={2}
+        style={{
+          width: '100%',
+          borderRadius: '6px',
+          border: '1px solid var(--line)',
+          padding: '4px 6px',
+          fontSize: '0.78rem',
+          background: 'var(--surface-soft)',
+          color: 'var(--text)',
+          resize: 'none',
+        }}
+      />
+    </div>
+  )
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export function GlobalMirrorPage() {
+  const { user } = useAuth()
+  const qc = useQueryClient()
+  const channelRef = useRef<RealtimeChannel | null>(null)
+
+  const [selectedPin, setSelectedPin] = useState<{ pin: MoodPin; svgX: number; svgY: number } | null>(null)
+  const [selectedSentiment, setSelectedSentiment] = useState<Sentiment>('happy')
+  const [geoStatus, setGeoStatus] = useState<'idle' | 'pending' | 'denied' | 'done'>('idle')
+  const [dropError, setDropError] = useState<string | null>(null)
+
+  const pinsQuery = useQuery({
+    queryKey: ['mood-pins'],
+    queryFn: fetchPins,
+    enabled: Boolean(user?.id),
+  })
+
+  // Supabase Realtime subscription
+  useEffect(() => {
+    const channel = supabase
+      .channel('mood_pins')
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'mood_pins' }, () => {
+        void qc.invalidateQueries({ queryKey: ['mood-pins'] })
+      })
+      .subscribe()
+    channelRef.current = channel
+    return () => { void supabase.removeChannel(channel) }
+  }, [qc])
+
+  const handleDropPin = useCallback(() => {
+    if (!user?.id) return
+    setGeoStatus('pending')
+    setDropError(null)
+
+    navigator.geolocation.getCurrentPosition(
+      async (pos) => {
+        try {
+          await insertPin(user.id, pos.coords.latitude, pos.coords.longitude, selectedSentiment)
+          setGeoStatus('done')
+          void qc.invalidateQueries({ queryKey: ['mood-pins'] })
+          setTimeout(() => setGeoStatus('idle'), 2000)
+        } catch (e) {
+          setDropError('Failed to drop pin. Please try again.')
+          setGeoStatus('idle')
+        }
+      },
+      () => {
+        setGeoStatus('denied')
+      },
+    )
+  }, [user?.id, selectedSentiment, qc])
+
+  const pins = pinsQuery.data ?? []
+
+  return (
+    <div className="page-wrap animate-stagger" style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      <h1>Global Mirror</h1>
+      <p className="muted">Live mood pins shared anonymously by users worldwide.</p>
+
+      {/* Map */}
+      <section className="card" style={{ overflow: 'hidden', position: 'relative' }}>
+        <svg
+          viewBox="0 0 800 400"
+          style={{ width: '100%', background: 'var(--surface-soft)', borderRadius: '12px', display: 'block' }}
+          aria-label="World mood map"
+        >
+          {/* Minimal world outline — simplified rectangle fill */}
+          <rect x={0} y={0} width={800} height={400} fill="var(--surface-soft)" />
+          <text x={400} y={200} textAnchor="middle" fill="var(--line)" fontSize={13}>
+            (World map outline — replace with react-simple-maps SVG paths)
+          </text>
+
+          {/* Mood pins */}
+          {pins.map((pin) => {
+            const { x, y } = toSvgCoord(pin.grid_lat, pin.grid_lon)
+            return (
+              <circle
+                key={pin.id}
+                cx={x}
+                cy={y}
+                r={5}
+                fill={SENTIMENT_COLOR[pin.sentiment] ?? 'var(--brand)'}
+                opacity={0.8}
+                style={{ cursor: 'pointer' }}
+                onClick={() => setSelectedPin({ pin, svgX: x, svgY: y })}
+              />
+            )
+          })}
+        </svg>
+
+        {/* Popover */}
+        {selectedPin && (
+          <PinPopover
+            pin={selectedPin.pin}
+            x={(selectedPin.svgX / 800) * 100 + '%' as unknown as number}
+            y={(selectedPin.svgY / 400) * 100 + '%' as unknown as number}
+            onClose={() => setSelectedPin(null)}
+          />
+        )}
+      </section>
+
+      {/* Drop pin */}
+      <section className="card">
+        <h2 style={{ marginTop: 0 }}>Drop your mood pin</h2>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '1rem' }}>
+          {SENTIMENTS.map((s) => (
+            <button
+              key={s.value}
+              type="button"
+              onClick={() => setSelectedSentiment(s.value)}
+              style={{
+                padding: '0.4rem 0.9rem',
+                borderRadius: '999px',
+                border: `2px solid ${selectedSentiment === s.value ? s.color : 'var(--line)'}`,
+                background: selectedSentiment === s.value ? s.color + '22' : 'transparent',
+                color: 'var(--text)',
+                cursor: 'pointer',
+                fontSize: '0.85rem',
+                fontWeight: selectedSentiment === s.value ? 600 : 400,
+              }}
+            >
+              {s.emoji} {s.label}
+            </button>
+          ))}
+        </div>
+
+        {geoStatus === 'denied' && (
+          <p style={{ color: 'var(--danger)', fontSize: '0.85rem', marginBottom: '0.5rem' }}>
+            Geolocation permission denied. Please allow location access in your browser settings.
+          </p>
+        )}
+        {dropError && (
+          <p style={{ color: 'var(--danger)', fontSize: '0.85rem', marginBottom: '0.5rem' }}>{dropError}</p>
+        )}
+
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={handleDropPin}
+          disabled={geoStatus === 'pending' || geoStatus === 'done'}
+          style={{ padding: '0.55rem 1.25rem', borderRadius: '10px', background: 'var(--brand)', color: '#fff', border: 'none', cursor: 'pointer', fontWeight: 600 }}
+        >
+          {geoStatus === 'pending' ? 'Getting location…' : geoStatus === 'done' ? '📍 Pinned!' : '📍 Drop pin'}
+        </button>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/features/notifications/notification-drawer.tsx
+++ b/frontend/src/features/notifications/notification-drawer.tsx
@@ -1,0 +1,208 @@
+/**
+ * NotificationDrawer  (#262)
+ *
+ * Slide-in panel listing unread mood-comment notifications.
+ * Toggled by the 🔔 bell button in app-shell.tsx.
+ * Closes on outside-click or Escape.
+ */
+import { useEffect, useRef } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../lib/auth-context'
+import { formatDateTime } from '../../lib/date'
+
+type Notification = {
+  id: string
+  created_at: string
+  sentiment: string
+  comment_preview: string
+  is_read: boolean
+}
+
+const SENTIMENT_EMOJI: Record<string, string> = {
+  happy: '😊',
+  sad: '😔',
+  stressed: '😤',
+  calm: '😌',
+  anxious: '😰',
+}
+
+async function fetchUnread(userId: string): Promise<Notification[]> {
+  const { data, error } = await supabase
+    .from('mood_comment_notifications')
+    .select('id, created_at, sentiment, comment_preview, is_read')
+    .eq('user_id', userId)
+    .eq('is_read', false)
+    .order('created_at', { ascending: false })
+    .limit(20)
+
+  if (error) throw error
+  return (data ?? []) as Notification[]
+}
+
+async function markOneRead(id: string) {
+  const { error } = await supabase
+    .from('mood_comment_notifications')
+    .update({ is_read: true })
+    .eq('id', id)
+  if (error) throw error
+}
+
+async function markAllRead(userId: string) {
+  const { error } = await supabase
+    .from('mood_comment_notifications')
+    .update({ is_read: true })
+    .eq('user_id', userId)
+    .eq('is_read', false)
+  if (error) throw error
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins} min ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return formatDateTime(iso)
+}
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function NotificationDrawer({ isOpen, onClose }: Props) {
+  const { user } = useAuth()
+  const qc = useQueryClient()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  const notificationsQuery = useQuery({
+    queryKey: ['unread-notifications-list', user?.id],
+    queryFn: () => fetchUnread(user!.id),
+    enabled: isOpen && Boolean(user?.id),
+  })
+
+  const markOneMutation = useMutation({
+    mutationFn: (id: string) => markOneRead(id),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['unread-notifications', user?.id] })
+      void qc.invalidateQueries({ queryKey: ['unread-notifications-list', user?.id] })
+    },
+  })
+
+  const markAllMutation = useMutation({
+    mutationFn: () => markAllRead(user!.id),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['unread-notifications', user?.id] })
+      void qc.invalidateQueries({ queryKey: ['unread-notifications-list', user?.id] })
+    },
+  })
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [isOpen, onClose])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!isOpen) return
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    // Delay one tick to avoid closing immediately on the open-click
+    const id = setTimeout(() => document.addEventListener('mousedown', handler), 0)
+    return () => {
+      clearTimeout(id)
+      document.removeEventListener('mousedown', handler)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const items = notificationsQuery.data ?? []
+
+  return (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label="Notifications"
+      aria-modal="true"
+      className="notification-drawer"
+      style={{
+        position: 'absolute',
+        top: '100%',
+        right: 0,
+        zIndex: 200,
+        width: 'min(380px, 94vw)',
+        background: 'var(--surface)',
+        border: '1px solid var(--line)',
+        borderRadius: 'var(--radius)',
+        boxShadow: 'var(--shadow)',
+        padding: '1rem',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
+        <strong style={{ fontSize: '0.95rem', color: 'var(--text)' }}>Notifications</strong>
+        {items.length > 0 && (
+          <button
+            type="button"
+            onClick={() => markAllMutation.mutate()}
+            disabled={markAllMutation.isPending}
+            style={{ fontSize: '0.75rem', color: 'var(--brand)', background: 'none', border: 'none', cursor: 'pointer' }}
+          >
+            Mark all as read
+          </button>
+        )}
+      </div>
+
+      {notificationsQuery.isLoading && (
+        <p style={{ color: 'var(--muted)', fontSize: '0.85rem' }}>Loading…</p>
+      )}
+
+      {!notificationsQuery.isLoading && items.length === 0 && (
+        <p style={{ color: 'var(--muted)', fontSize: '0.85rem', textAlign: 'center', padding: '1.5rem 0' }}>
+          No new notifications
+        </p>
+      )}
+
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        {items.map((n) => (
+          <li
+            key={n.id}
+            onClick={() => markOneMutation.mutate(n.id)}
+            style={{
+              display: 'flex',
+              gap: '0.6rem',
+              alignItems: 'flex-start',
+              padding: '0.6rem',
+              borderRadius: '10px',
+              cursor: 'pointer',
+              background: 'var(--surface-soft)',
+              transition: 'opacity 0.15s',
+            }}
+          >
+            <span style={{ fontSize: '1.3rem', lineHeight: 1 }}>
+              {SENTIMENT_EMOJI[n.sentiment?.toLowerCase()] ?? '💬'}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <p style={{ margin: 0, fontSize: '0.82rem', color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {n.comment_preview?.slice(0, 80) ?? '(no preview)'}
+              </p>
+              <p style={{ margin: '2px 0 0', fontSize: '0.72rem', color: 'var(--muted)' }}>
+                {relativeTime(n.created_at)}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/lib/use-theme.ts
+++ b/frontend/src/lib/use-theme.ts
@@ -1,0 +1,65 @@
+/**
+ * useTheme — dark / light / system theme hook  (#263)
+ *
+ * Persists the chosen theme in localStorage under 'echo-theme'.
+ * Applies data-theme="dark" or data-theme="light" on <html>.
+ * Falls back to the OS preference when theme is 'system'.
+ */
+import { useCallback, useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark' | 'system'
+
+const STORAGE_KEY = 'echo-theme'
+
+function resolveApplied(theme: Theme): 'light' | 'dark' {
+  if (theme === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  return theme
+}
+
+function applyTheme(theme: Theme) {
+  const applied = resolveApplied(theme)
+  if (applied === 'dark') {
+    document.documentElement.setAttribute('data-theme', 'dark')
+  } else {
+    document.documentElement.removeAttribute('data-theme')
+  }
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
+    } catch {
+      // ignore (SSR / private browsing)
+    }
+    return 'system'
+  })
+
+  // Apply on mount and whenever theme changes
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  // Track OS preference changes when in 'system' mode
+  useEffect(() => {
+    if (theme !== 'system') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = () => applyTheme('system')
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [theme])
+
+  const setTheme = useCallback((next: Theme) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, next)
+    } catch {
+      // ignore
+    }
+    setThemeState(next)
+  }, [])
+
+  return { theme, setTheme }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -15,6 +15,40 @@
   --warning: #e67a00;
   --radius: 16px;
   --shadow: 0 14px 30px rgba(17, 33, 56, 0.08);
+  --accent: #8b5cf6;
+  --accent-secondary: #ec4899;
+  --border: var(--line);
+}
+
+/* #263 — dark theme */
+[data-theme='dark'] {
+  --bg: #0f0f13;
+  --bg-accent: #12161e;
+  --surface: #1a1a24;
+  --surface-soft: #1f1f2e;
+  --text: #f3f4f6;
+  --muted: #9ca3af;
+  --line: #2d2d3a;
+  --border: #2d2d3a;
+  --brand: #818cf8;
+  --brand-strong: #a5b4fc;
+  --shadow: 0 14px 30px rgba(0, 0, 0, 0.4);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --bg: #0f0f13;
+    --bg-accent: #12161e;
+    --surface: #1a1a24;
+    --surface-soft: #1f1f2e;
+    --text: #f3f4f6;
+    --muted: #9ca3af;
+    --line: #2d2d3a;
+    --border: #2d2d3a;
+    --brand: #818cf8;
+    --brand-strong: #a5b4fc;
+    --shadow: 0 14px 30px rgba(0, 0, 0, 0.4);
+  }
 }
 
 * {


### PR DESCRIPTION
## Summary

- Closes #259 — **Analytics page** (`/analytics`): replaces `PlaceholderPage`; installs Recharts (`package.json`); renders a **mood trend LineChart** (daily scores over 30 days), a **habit frequency BarChart** (top 8 habits from `log_entries.habits` JSONB, aggregated client-side), and a **12-week streak calendar** grid (GitHub-style filled/empty cells); loading skeleton and empty-state message when no entries exist.

- Closes #260 — **Global Mirror page** (`/global-mirror`): replaces `PlaceholderPage`; SVG world map with mood pins plotted as coloured dots (colour keyed to sentiment); **Supabase Realtime** subscription on `mood_pins` — new pins appear without page refresh; **drop-a-pin** panel with 5-sentiment selector and `navigator.geolocation` permission gate — coordinates anonymized to 1 decimal place matching the mobile `MoodPinModel.anonymizeCoordinate()`; pin popover with comment input; graceful "permission denied" fallback.

- Closes #262 — **Notification drawer**: clicking the existing 🔔 bell in `app-shell.tsx` now opens/closes an inline panel; fetches up to 20 unread rows from `mood_comment_notifications` (only when panel is open, via `enabled: isPanelOpen`); shows sentiment emoji + 80-char comment preview + relative time; clicking a row marks it `is_read = true` (optimistic removal, badge count updated via query invalidation); "Mark all as read" bulk-updates; empty state; closes on Escape and outside-click.

- Closes #263 — **Dark mode** (CSS + persistence): adds `[data-theme='dark']` token set and a `@media (prefers-color-scheme: dark)` fallback to `styles.css`; creates `lib/use-theme.ts` — reads `localStorage('echo-theme')` on init (fallback `'system'`), applies/removes `data-theme="dark"` on `<html>`, listens to OS preference changes when in `'system'` mode, exposes `{ theme, setTheme }` for the Settings toggle (issue #261).

## Test plan

- [x] `tsc --noEmit` → 0 errors
- [ ] `/analytics` renders charts with real `log_entries` data; empty state when no entries
- [ ] `/global-mirror` plots pins, live-updates on new insert, pin drop requests geolocation, shows denial fallback
- [ ] Bell opens notification panel; clicking a notification removes it from list and decrements badge
- [ ] "Mark all as read" clears all notifications; badge goes to 0
- [ ] Setting `localStorage.setItem('echo-theme', 'dark')` and refreshing applies dark tokens; `'system'` follows OS