### PR TITLE
Fix/issue 215 pin flutter sdk

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,1 @@
+{ "flutterSdkVersion": "3.41.7", "flavors": {} }

--- a/README.md
+++ b/README.md
@@ -139,7 +139,16 @@ We believe wellness is better together. EchoMirror Butler helps you:
 ```bash
 git clone https://github.com/Echo-Mirror-Butler/Echo-Mirror-Butler-.git
 cd Echo-Mirror-Butler-
-flutter pub get
+
+# Install FVM
+dart pub global activate fvm
+
+# Use the pinned version
+fvm install
+fvm flutter --version # should show 3.41.7
+
+# Run all dart commands via fvm
+fvm flutter pub get
 ```
 
 ---
@@ -177,7 +186,7 @@ source ~/.zshrc
 
 **Terminal:**
 ```bash
-flutter run -d "iPhone 16 Pro" \
+fvm flutter run -d "iPhone 16 Pro" \
   --dart-define=SUPABASE_URL=$SUPABASE_URL \
   --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
 ```
@@ -342,26 +351,26 @@ For AI setup instructions, refer to your Supabase dashboard or use `supabase sec
 ### Running Tests
 
 ```bash
-flutter test
+fvm flutter test
 ```
 
 ### Code Analysis
 
 ```bash
-flutter analyze
+fvm flutter analyze
 ```
 
 ### Format Code
 
 ```bash
-flutter format .
+fvm dart format lib test backend
 ```
 
 ### Generate Code
 
 ```bash
 # For Riverpod code generation
-flutter pub run build_runner build
+fvm flutter pub run build_runner build
 ```
 
 ---


### PR DESCRIPTION
## 📝 Description

This PR fixes the recurring CI pipeline format failures caused by contributors using mismatched local Flutter SDK versions. To ensure a consistent `dart format` output across all environments, we are now enforcing the use of the **Flutter Version Management (FVM)** tool to pin the SDK version.

## Closes #215

### 🛠️ Changes Made
- **Pinned Flutter SDK**: Added a `.fvm/fvm_config.json` file at the repository root to explicitly pin the Flutter SDK to version `3.41.7`.
- **Updated Contributor Guide**: Modified the `README.md` to:
  - Add instructions for installing `fvm` (`dart pub global activate fvm`).
  - Require the use of `fvm install` during the initial project setup.
  - Update all `flutter` and `dart` commands in the "Getting Started" and "Development" sections to use their `fvm` prefixed equivalents (e.g., `fvm flutter pub get`, `fvm dart format lib test backend`).

### 🧪 How to Test
1. Run `dart pub global activate fvm` to install FVM globally if you haven't already.
2. Run `fvm install` in the repository root.
3. Verify that `fvm flutter --version` successfully reports version `3.41.7`.
4. Run `fvm dart format lib test backend` and verify that the formatting remains consistent with the CI environment.

### 📋 Checklist
- [x] Tested locally
- [x] Updated documentation (`README.md`)
- [x] Follows the project's commit style guidelines
