### PR TITLE
fix(web): resolve TypeScript environment errors and restore tsc to bu…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "description": "This directory will contain the React web application for EchoMirror — a companion web dashboard to the Flutter mobile app.",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
This pull request updates the frontend build process to improve type safety. The most important change is:

Build process improvement:
* Updated the `build` script in `frontend/package.json` to run TypeScript type checking (`tsc --noEmit`) before building with Vite, ensuring type errors are caught during the build process.

Closes #345 
