### PR TITLE
fix and feat: repair how-it-works reveal, fix stat colors, add quick-log widget, wire global mirror

### DIFF
--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../lib/auth-context'
 import type { LogEntry, Insight } from '../../lib/types'
@@ -96,6 +97,135 @@ async function fetchLatestInsight(userId: string): Promise<Insight | null> {
   }
 
   return (data as Insight) ?? null
+}
+
+async function logMoodEntry(
+  userId: string,
+  mood: number,
+  notes: string,
+): Promise<void> {
+  const today = new Date().toISOString().split('T')[0]
+  const { error } = await supabase.from('log_entries').insert({
+    user_id: userId,
+    date: today,
+    mood,
+    notes: notes.trim() || null,
+    habits: [],
+  })
+  if (error) throw error
+}
+
+async function fetchTodayLog(userId: string): Promise<number | null> {
+  const today = new Date().toISOString().split('T')[0]
+  const { data } = await supabase
+    .from('log_entries')
+    .select('mood')
+    .eq('user_id', userId)
+    .eq('date', today)
+    .maybeSingle()
+  return (data as { mood: number } | null)?.mood ?? null
+}
+
+const MOOD_EMOJIS: Record<number, string> = { 1: '😔', 2: '😕', 3: '😐', 4: '🙂', 5: '😄' }
+
+function QuickLogWidget({ userId }: { userId: string }) {
+  const queryClient = useQueryClient()
+  const [selectedMood, setSelectedMood] = useState<number | null>(null)
+  const [notes, setNotes] = useState('')
+  const [status, setStatus] = useState<'idle' | 'saving' | 'done' | 'error'>('idle')
+
+  const todayQuery = useQuery({
+    queryKey: ['today-log', userId],
+    queryFn: () => fetchTodayLog(userId),
+    enabled: Boolean(userId),
+  })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!selectedMood) return
+    setStatus('saving')
+    try {
+      await logMoodEntry(userId, selectedMood, notes)
+      setStatus('done')
+      void queryClient.invalidateQueries({ queryKey: ['dashboard-streak', userId] })
+      void queryClient.invalidateQueries({ queryKey: ['dashboard-recent-logs', userId] })
+      void queryClient.invalidateQueries({ queryKey: ['today-log', userId] })
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  if (todayQuery.isLoading) {
+    return (
+      <article className="card">
+        <h2>Log Today's Mood</h2>
+        <div className="skeleton-line" />
+      </article>
+    )
+  }
+
+  if (todayQuery.data !== null && todayQuery.data !== undefined) {
+    return (
+      <article className="card">
+        <h2>Log Today's Mood</h2>
+        <p className="muted">
+          Logged today {MOOD_EMOJIS[todayQuery.data] ?? ''}
+        </p>
+        <Link to="/logs" className="chip" style={{ marginTop: '0.5rem', display: 'inline-block' }}>
+          View logs
+        </Link>
+      </article>
+    )
+  }
+
+  return (
+    <article className="card">
+      <h2>Log Today's Mood</h2>
+      {status === 'done' ? (
+        <p className="muted">Mood logged! {selectedMood ? MOOD_EMOJIS[selectedMood] : ''}</p>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+            {([1, 2, 3, 4, 5] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setSelectedMood(m)}
+                style={{
+                  fontSize: '1.5rem',
+                  background: 'none',
+                  border: selectedMood === m ? '2px solid var(--color-accent, #6366f1)' : '2px solid transparent',
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  padding: '0.25rem',
+                  lineHeight: 1,
+                }}
+                aria-label={`Mood ${m}`}
+              >
+                {MOOD_EMOJIS[m]}
+              </button>
+            ))}
+          </div>
+          <textarea
+            className="field"
+            placeholder="Optional note…"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={2}
+            style={{ width: '100%', marginBottom: '0.5rem', resize: 'vertical' }}
+          />
+          {status === 'error' && <p className="muted" style={{ color: 'red', marginBottom: '0.5rem' }}>Failed to save. Try again.</p>}
+          <button
+            type="submit"
+            className="chip"
+            disabled={!selectedMood || status === 'saving'}
+          >
+            {status === 'saving' ? 'Saving…' : 'Save mood'}
+          </button>
+        </form>
+      )}
+    </article>
+  )
 }
 
 export function DashboardPage() {
@@ -221,6 +351,9 @@ export function DashboardPage() {
           </div>
         )}
       </article>
+
+      {/* Quick Mood Log Widget */}
+      <QuickLogWidget userId={user.id} />
     </section>
   )
 }

--- a/frontend/src/features/global-mirror/global-mirror-page.tsx
+++ b/frontend/src/features/global-mirror/global-mirror-page.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../../lib/supabase'
+
+interface MoodPin {
+  lat: number
+  lon: number
+  sentiment: string
+  created_at: string
+}
+
+const SENTIMENT_COLOR: Record<string, string> = {
+  positive: '#0a8a5b',
+  negative: '#bb2d3b',
+  neutral: '#6366f1',
+}
+
+function getSentimentColor(sentiment: string): string {
+  return SENTIMENT_COLOR[sentiment.toLowerCase()] ?? '#6366f1'
+}
+
+export function GlobalMirrorPage() {
+  const [pins, setPins] = useState<MoodPin[]>([])
+  const [loading, setLoading] = useState(true)
+  const [liveCount, setLiveCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadInitialPins() {
+      const { data } = await supabase
+        .from('mood_pins')
+        .select('lat, lon, sentiment, created_at')
+        .order('created_at', { ascending: false })
+        .limit(20)
+
+      if (!cancelled && data) {
+        setPins(data as MoodPin[])
+        setLiveCount(data.length)
+      }
+      setLoading(false)
+    }
+
+    void loadInitialPins()
+
+    const channel = supabase
+      .channel('mood_pins_realtime')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'mood_pins' },
+        (payload) => {
+          if (cancelled) return
+          const newPin = payload.new as MoodPin
+          setPins((prev) => [newPin, ...prev].slice(0, 20))
+          setLiveCount((c) => c + 1)
+        },
+      )
+      .subscribe()
+
+    return () => {
+      cancelled = true
+      void supabase.removeChannel(channel)
+    }
+  }, [])
+
+  const sentimentCounts = pins.reduce<Record<string, number>>((acc, pin) => {
+    const key = pin.sentiment?.toLowerCase() ?? 'neutral'
+    acc[key] = (acc[key] ?? 0) + 1
+    return acc
+  }, {})
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: '900px', margin: '0 auto' }}>
+      <h1 style={{ marginBottom: '0.5rem' }}>Global Mirror</h1>
+      <p style={{ color: 'var(--color-muted, #6b7280)', marginBottom: '1.5rem' }}>
+        {loading
+          ? 'Loading live mood data…'
+          : liveCount > 0
+            ? `${liveCount} ${liveCount === 1 ? 'person' : 'people'} sharing right now`
+            : 'No mood pins yet — be the first to share.'}
+      </p>
+
+      {/* Sentiment distribution rings */}
+      {!loading && pins.length > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            gap: '1rem',
+            marginBottom: '2rem',
+            flexWrap: 'wrap',
+          }}
+        >
+          {Object.entries(sentimentCounts).map(([sentiment, count]) => (
+            <div
+              key={sentiment}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.5rem',
+                padding: '0.5rem 1rem',
+                borderRadius: '999px',
+                background: `${getSentimentColor(sentiment)}22`,
+                border: `1.5px solid ${getSentimentColor(sentiment)}`,
+              }}
+            >
+              <span
+                style={{
+                  width: '10px',
+                  height: '10px',
+                  borderRadius: '50%',
+                  background: getSentimentColor(sentiment),
+                  display: 'inline-block',
+                }}
+              />
+              <span style={{ textTransform: 'capitalize', fontWeight: 600 }}>
+                {sentiment}
+              </span>
+              <span style={{ color: 'var(--color-muted, #6b7280)' }}>{count}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Live ticker strip */}
+      {loading ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="skeleton-line" />
+          ))}
+        </div>
+      ) : pins.length === 0 ? (
+        <div className="empty-state">
+          <p className="muted">No mood pins have been shared yet.</p>
+        </div>
+      ) : (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.5rem',
+            maxHeight: '480px',
+            overflowY: 'auto',
+          }}
+        >
+          {pins.map((pin, idx) => (
+            <div
+              key={`${pin.created_at}-${idx}`}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.75rem',
+                padding: '0.75rem 1rem',
+                borderRadius: '10px',
+                background: 'var(--color-surface, #f9fafb)',
+                border: '1px solid var(--color-border, #e5e7eb)',
+                borderLeft: `4px solid ${getSentimentColor(pin.sentiment)}`,
+              }}
+            >
+              <span
+                style={{
+                  width: '10px',
+                  height: '10px',
+                  borderRadius: '50%',
+                  background: getSentimentColor(pin.sentiment),
+                  flexShrink: 0,
+                }}
+              />
+              <span style={{ fontWeight: 600, textTransform: 'capitalize' }}>
+                {pin.sentiment}
+              </span>
+              <span style={{ color: 'var(--color-muted, #6b7280)', fontSize: '0.82rem' }}>
+                {pin.lat.toFixed(2)}, {pin.lon.toFixed(2)}
+              </span>
+              <span
+                style={{
+                  marginLeft: 'auto',
+                  color: 'var(--color-muted, #6b7280)',
+                  fontSize: '0.78rem',
+                }}
+              >
+                {new Date(pin.created_at).toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -62,10 +62,20 @@ function useReveal() {
     const el = ref.current
     if (!el) return
     const observer = new IntersectionObserver(
-      ([entry]) => { if (entry.isIntersecting) { el.classList.add('is-visible'); observer.disconnect() } },
-      { threshold: 0.08 },
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          el.classList.add('is-visible')
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.08, rootMargin: '0px 0px -20px 0px' },
     )
     observer.observe(el)
+    // Fallback: if element is already fully in view on mount, reveal it immediately.
+    if (el.getBoundingClientRect().top < window.innerHeight) {
+      el.classList.add('is-visible')
+      observer.disconnect()
+    }
     return () => observer.disconnect()
   }, [])
   return ref

--- a/frontend/src/features/landing/landing-page.css
+++ b/frontend/src/features/landing/landing-page.css
@@ -1253,7 +1253,6 @@ a.lp-cta-ghost:hover { color: rgba(255,255,255,0.8) !important; }
   font-family: 'Instrument Serif', serif;
   font-size: 2.2rem;
   font-weight: 400;
-  color: var(--lp-blue);
   line-height: 1;
   margin-bottom: 0.5rem;
 }
@@ -1925,6 +1924,7 @@ a.lp-cta-ghost:hover { color: rgba(255,255,255,0.8) !important; }
   color: var(--lp-ink);
   margin-bottom: 0.6rem;
   letter-spacing: -0.01em;
+  visibility: visible;
 }
 
 .lp-how-body {
@@ -1932,6 +1932,7 @@ a.lp-cta-ghost:hover { color: rgba(255,255,255,0.8) !important; }
   line-height: 1.65;
   color: var(--lp-ink-60);
   font-weight: 300;
+  visibility: visible;
 }
 
 /* ── Testimonials section ────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Fix `useReveal` hook to immediately reveal elements already in viewport on mount; add `rootMargin` so the IntersectionObserver triggers reliably for the how-it-works section; add `visibility: visible` to `.lp-how-title` and `.lp-how-body` to prevent accidental hiding
- Remove hardcoded `color: var(--lp-blue)` from `.lp-awareness-stat-value` so each stat's per-stat inline color renders correctly instead of all stats defaulting to blue
- Add `QuickLogWidget` component to DashboardPage: 5-emoji mood picker (1–5), optional notes textarea, today-already-logged guard showing read-only state, pending state with disabled button, cache invalidation for streak/logs/today queries on success
- Create `global-mirror-page.tsx` with initial Supabase query for 20 most recent `mood_pins`, Supabase Realtime INSERT subscription for live updates, sentiment distribution rings, live pin count, and scrollable pin ticker strip

## Test plan

- [ ] Scroll to How It Works section and confirm all 3 step titles and body text are visible
- [ ] Navigate to landing page and confirm each of the 4 awareness stats shows its distinct colour (blue, red, green, purple)
- [ ] Open dashboard and confirm the "Log Today's Mood" card is present; select emoji + notes and submit; confirm streak/logs invalidate
- [ ] Log mood for today and confirm card shows read-only "Logged today" state on next load
- [ ] Navigate to the global mirror page and confirm live mood pins load and update via Realtime

Closes #380
Closes #381
Closes #382
Closes #383