### PR TITLE
fix(web/logs): cannot create log entries — form submits but silently fails when user is not authenticated in router context

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,21 +1,3 @@
-import { Navigate, Route, Routes } from 'react-router-dom'
-import { AppShell } from '../components/layout/app-shell'
-import { SignInPanel } from '../components/auth/sign-in-panel'
-import { LandingPage } from '../features/landing/LandingPage'
-import { useAuth } from '../lib/auth-context'
-import { WalletPage } from '../features/wallet/wallet-page'
-import { LogsListPage } from '../features/logs/logs-list-page'
-import { LogFormPage } from '../features/logs/log-form-page'
-import { InsightsPage } from '../features/insights/insights-page'
-import { AnalyticsPage } from '../features/analytics/analytics-page'
-import { GlobalMirrorPage } from '../features/global-mirror/global-mirror-page'
-import { DashboardPage } from '../features/dashboard/dashboard-page'
-import { SettingsPage } from '../features/settings/settings-page'
-import { ErrorBoundary } from '../components/error-boundary'
-import NotFoundPage from '../features/shared/not-found-page'
-import { SignupPage } from '../features/auth/pages/SignupPage'
-import { ResetPasswordPage } from '../features/auth/pages/ResetPasswordPage'
-import { UpdatePasswordPage } from '../features/auth/pages/UpdatePasswordPage'
 import { Navigate, Route, Routes } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { AppShell } from "../components/layout/app-shell";
@@ -107,10 +89,6 @@ export function AppRouter() {
         path="/"
         element={user ? <Navigate to="/dashboard" replace /> : <LandingPage />}
       />
-      <Route path="/login" element={user ? <Navigate to="/dashboard" replace /> : <SignInPanel />} />
-      <Route path="/signup" element={user ? <Navigate to="/dashboard" replace /> : <SignupPage />} />
-      <Route path="/reset-password" element={user ? <Navigate to="/dashboard" replace /> : <ResetPasswordPage />} />
-      <Route path="/update-password" element={user ? <Navigate to="/dashboard" replace /> : <UpdatePasswordPage />} />
       <Route
         path="/login"
         element={user ? <Navigate to="/dashboard" replace /> : <SignInPanel />}

--- a/frontend/src/features/logs/log-form-page.test.tsx
+++ b/frontend/src/features/logs/log-form-page.test.tsx
@@ -1,0 +1,118 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { ToastProvider } from '../../lib/use-toast'
+import { LogFormPage } from './log-form-page'
+
+const insertMock = vi.fn()
+const maybeSingleMock = vi.fn()
+const singleMock = vi.fn()
+
+vi.mock('../../lib/auth-context', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'test-user-id',
+      email: 'test@example.com',
+      user_metadata: { onboarding_completed: true },
+    },
+    session: null,
+    isLoading: false,
+    signOut: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => {
+      const builder = {
+        select: vi.fn(() => builder),
+        eq: vi.fn(() => builder),
+        gte: vi.fn(() => builder),
+        lte: vi.fn(() => builder),
+        insert: insertMock.mockImplementation(() => builder),
+        update: vi.fn(() => builder),
+        delete: vi.fn(() => builder),
+        maybeSingle: maybeSingleMock,
+        single: singleMock,
+      }
+      return builder
+    }),
+  },
+}))
+
+function renderCreateForm() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/logs/new']}>
+        <ToastProvider>
+          <Routes>
+            <Route path='/logs/new' element={<LogFormPage mode='create' />} />
+            <Route path='/logs' element={<h1>Logs list</h1>} />
+          </Routes>
+        </ToastProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('LogFormPage', () => {
+  beforeEach(() => {
+    insertMock.mockClear()
+    maybeSingleMock.mockResolvedValue({ data: null, error: null })
+    singleMock.mockResolvedValue({
+      data: {
+        id: 'created-log-id',
+        user_id: 'test-user-id',
+        date: new Date().toISOString(),
+        mood: 3,
+        habits: [],
+        notes: 'Vitest create flow note',
+      },
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('shows an inline mood validation error when saving without a mood', async () => {
+    const user = userEvent.setup()
+    renderCreateForm()
+
+    await user.click(screen.getByRole('button', { name: /save log entry/i }))
+
+    expect(await screen.findByText('Mood score is required')).toBeInTheDocument()
+    expect(insertMock).not.toHaveBeenCalled()
+  })
+
+  test('creates a log entry, shows a success toast, and redirects to logs', async () => {
+    const user = userEvent.setup()
+    renderCreateForm()
+
+    await user.click(screen.getByRole('button', { name: 'Mood 3' }))
+    await user.type(screen.getByPlaceholderText(/optional notes/i), 'Vitest create flow note')
+    await user.click(screen.getByRole('button', { name: /save log entry/i }))
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1))
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'test-user-id',
+        mood: 3,
+        habits: [],
+        notes: 'Vitest create flow note',
+      }),
+    )
+    expect(await screen.findByText('Mood logged! +1 ECHO earned 🎉')).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: /logs list/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/logs/log-form-page.tsx
+++ b/frontend/src/features/logs/log-form-page.tsx
@@ -118,6 +118,9 @@ export function LogFormPage({ mode }: LogFormPageProps) {
     if (selectedDate > today) {
       errors.date = 'Date cannot be in the future'
     }
+    if (mood === null) {
+      errors.mood = 'Mood score is required'
+    }
     if (notes.length > MAX_NOTES_LENGTH) {
       errors.notes = `Notes must be under ${MAX_NOTES_LENGTH} characters`
     }
@@ -182,18 +185,15 @@ export function LogFormPage({ mode }: LogFormPageProps) {
       setFieldErrors({})
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['logs', user?.id] })
-      await queryClient.invalidateQueries({ queryKey: ['log-entry', id] })
-      setToast({ show: true, message: 'Log saved successfully!', type: 'success' })
-      // Redirect after 1.5 seconds to allow toast to be seen
-      setTimeout(() => {
-        navigate('/logs')
-      }, 1500)
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['logs', user?.id] }),
+        queryClient.invalidateQueries({ queryKey: ['log-entry', id] }),
+      ])
       showToast(mode === 'create' ? 'Mood logged! +1 ECHO earned 🎉' : 'Changes saved', 'success')
       navigate('/logs')
     },
     onError: (error: Error) => {
-      setToast({ show: true, message: error.message, type: 'error' })
+      setFormError(error.message)
     },
   })
 
@@ -245,24 +245,6 @@ export function LogFormPage({ mode }: LogFormPageProps) {
     }
   }
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    // Validate mood is required and between 1-5
-    if (mood === null || mood < 1 || mood > 5) {
-      setFormError('Mood score is required and must be between 1 and 5.')
-      return
-    }
-    // Validate date is not in the future
-    const selectedDate = new Date(date)
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-    if (selectedDate > today) {
-      setFormError('Date cannot be in the future.')
-      return
-    }
-    saveMutation.mutate()
-  }
-
   if (!user) {
     return null
   }
@@ -287,9 +269,9 @@ export function LogFormPage({ mode }: LogFormPageProps) {
 
         <form
           className="form-stack"
-          onSubmit={handleSubmit}
           onSubmit={(event: FormEvent<HTMLFormElement>) => {
             event.preventDefault()
+            setFormError(null)
             if (!validate()) return
             saveMutation.mutate()
           }}
@@ -311,7 +293,10 @@ export function LogFormPage({ mode }: LogFormPageProps) {
                     type="button"
                     style={{ fontSize: '1.3rem', padding: '0.5rem 0.8rem' }}
                     className={mood === value ? 'chip active' : 'chip'}
-                    onClick={() => setMood((prev) => (prev === value ? null : value))}
+                    onClick={() => {
+                      setMood((prev) => (prev === value ? null : value))
+                      setFieldErrors((prev) => ({ ...prev, mood: undefined }))
+                    }}
                     aria-label={`Mood ${value}`}
                   >
                     {emoji}
@@ -319,6 +304,7 @@ export function LogFormPage({ mode }: LogFormPageProps) {
                 )
               })}
             </div>
+            {fieldErrors.mood && <p className="error-text" style={{ marginTop: '0.25rem' }}>{fieldErrors.mood}</p>}
           </div>
 
           <div>
@@ -354,7 +340,7 @@ export function LogFormPage({ mode }: LogFormPageProps) {
                   className="chip active"
                   onClick={() => setHabits((prev) => prev.filter((item) => item !== habit))}
                 >
-                  {habit} A-
+                  {habit} ×
                 </button>
               ))}
             </div>
@@ -381,7 +367,7 @@ export function LogFormPage({ mode }: LogFormPageProps) {
           </label>
 
           <button type="submit" disabled={saveMutation.isPending}>
-            {saveMutation.isPending ? 'Saving�?�' : 'Save log entry'}
+            {saveMutation.isPending ? 'Saving…' : 'Save log entry'}
           </button>
 
           {mode === 'edit' ? (
@@ -396,7 +382,7 @@ export function LogFormPage({ mode }: LogFormPageProps) {
               }}
               disabled={deleteMutation.isPending}
             >
-              {deleteMutation.isPending ? 'Deleting�?�' : 'Delete entry'}
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete entry'}
             </button>
           ) : null}
 


### PR DESCRIPTION
Closes #398 

Tasks
 Add `mood` as a required field in `validate()` — show an inline error `"Mood score is required"` if the user hasn't selected one, instead of letting it fall through to the mutation
 Verify `useToast` does not throw when the form renders — check that `AppProviders` wraps all authenticated routes
 Test the full create flow: select a mood, add notes, submit — confirm a row appears in Supabase `log_entries`
 Test the error path: submit with no mood — confirm inline error appears