### PR TITLE
fix(web/wallet): harden Freighter connection and Stellar testnet flow

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,9 @@
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 VITE_STELLAR_NETWORK=testnet
+# Optional overrides — defaults are derived from VITE_STELLAR_NETWORK (see src/lib/stellar-config.ts)
+# VITE_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+# VITE_STELLAR_EXPLORER_BASE_URL=https://stellar.expert/explorer/testnet/tx/
 
 # Issue #303 — Web Push notifications (VAPID)
 # Generate with: npx web-push generate-vapid-keys

--- a/frontend/src/features/wallet/wallet-page.test.tsx
+++ b/frontend/src/features/wallet/wallet-page.test.tsx
@@ -4,13 +4,27 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { ToastProvider } from '../../lib/use-toast'
+import { stellarConfig } from '../../lib/stellar-config'
 import { WalletPage } from './wallet-page'
 
 let mockFreighterInstalled = false
-let mockRequestAccessResult = { address: '', error: null }
+let mockRequestAccessResult: { address: string; error: { message?: string } | null } = {
+  address: '',
+  error: null,
+}
+let mockGetNetworkResult: {
+  network: string
+  networkPassphrase: string
+  error: { message?: string } | null
+} = {
+  network: 'TESTNET',
+  networkPassphrase: stellarConfig.networkPassphrase,
+  error: null,
+}
 
 const mockFrom = vi.hoisted(() => vi.fn())
 const mockInvoke = vi.hoisted(() => vi.fn())
+const mockRpc = vi.hoisted(() => vi.fn())
 
 vi.mock('../../lib/auth-context', () => ({
   useAuth: () => ({
@@ -31,11 +45,13 @@ vi.mock('../../lib/supabase', () => ({
     functions: {
       invoke: mockInvoke,
     },
+    rpc: mockRpc,
   },
 }))
 
 vi.mock('@stellar/freighter-api', () => ({
   requestAccess: vi.fn(() => Promise.resolve(mockRequestAccessResult)),
+  getNetwork: vi.fn(() => Promise.resolve(mockGetNetworkResult)),
 }))
 
 Object.defineProperty(window, 'freighter', {
@@ -82,8 +98,15 @@ describe('WalletPage', () => {
   beforeEach(() => {
     mockFrom.mockClear()
     mockInvoke.mockClear()
+    mockRpc.mockClear()
+    mockRpc.mockResolvedValue({ data: null, error: null })
     mockFreighterInstalled = false
     mockRequestAccessResult = { address: '', error: null }
+    mockGetNetworkResult = {
+      network: 'TESTNET',
+      networkPassphrase: stellarConfig.networkPassphrase,
+      error: null,
+    }
   })
 
   afterEach(() => {
@@ -129,6 +152,102 @@ describe('WalletPage', () => {
       expect(screen.getByText(/Freighter not found/i)).toBeInTheDocument()
       expect(screen.getByText('Install Freighter')).toBeInTheDocument()
     })
+  })
+
+  test('connects via Freighter and shows the address when the network matches testnet', async () => {
+    const walletChain = createMockChain({
+      id: 'wallet-1',
+      user_id: 'test-user-id',
+      public_key: null,
+      balance: 0,
+    })
+    mockFrom.mockReturnValue(walletChain)
+    mockFreighterInstalled = true
+    mockRequestAccessResult = {
+      address: 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD',
+      error: null,
+    }
+    mockGetNetworkResult = {
+      network: 'TESTNET',
+      networkPassphrase: stellarConfig.networkPassphrase,
+      error: null,
+    }
+
+    const user = userEvent.setup()
+    renderWalletPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Connect Freighter')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Connect Freighter'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Connected via Freighter')).toBeInTheDocument()
+    })
+  })
+
+  test('shows an error when the user rejects the Freighter connection request', async () => {
+    const walletChain = createMockChain({
+      id: 'wallet-1',
+      user_id: 'test-user-id',
+      public_key: null,
+      balance: 0,
+    })
+    mockFrom.mockReturnValue(walletChain)
+    mockFreighterInstalled = true
+    mockRequestAccessResult = {
+      address: '',
+      error: { message: 'User declined access' },
+    }
+
+    const user = userEvent.setup()
+    renderWalletPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Connect Freighter')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Connect Freighter'))
+
+    await waitFor(() => {
+      expect(screen.getByText('User declined access')).toBeInTheDocument()
+    })
+  })
+
+  test('rejects a Freighter connection on the wrong network', async () => {
+    const walletChain = createMockChain({
+      id: 'wallet-1',
+      user_id: 'test-user-id',
+      public_key: null,
+      balance: 0,
+    })
+    mockFrom.mockReturnValue(walletChain)
+    mockFreighterInstalled = true
+    mockRequestAccessResult = {
+      address: 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD',
+      error: null,
+    }
+    mockGetNetworkResult = {
+      network: 'PUBLIC',
+      networkPassphrase: 'Public Global Stellar Network ; September 2015',
+      error: null,
+    }
+
+    const user = userEvent.setup()
+    renderWalletPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Connect Freighter')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Connect Freighter'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Freighter is set to PUBLIC/i)).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('Connected via Freighter')).not.toBeInTheDocument()
   })
 
   test('displays wallet address and balance after successful connection', async () => {
@@ -209,7 +328,117 @@ describe('WalletPage', () => {
     await user.click(sendButton)
 
     await waitFor(() => {
-      expect(screen.getByText(/Could not resolve recipient/i)).toBeInTheDocument()
+      expect(screen.getAllByText(/Could not resolve recipient/i).length).toBeGreaterThan(0)
+    })
+  })
+
+  function createUserWalletsTableMock(
+    senderRecord: Record<string, unknown>,
+    recipientLookupResult: { data: unknown; error: unknown },
+  ) {
+    let lastEqField: string | null = null
+    const chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn((field: string) => {
+        lastEqField = field
+        return chain
+      }),
+      maybeSingle: vi.fn(() =>
+        lastEqField === 'public_key'
+          ? Promise.resolve(recipientLookupResult)
+          : Promise.resolve({ data: senderRecord, error: null }),
+      ),
+      upsert: vi.fn(() => chain),
+    }
+    return chain
+  }
+
+  test('shows "Address not found" for an unknown Stellar address recipient', async () => {
+    const senderRecord = {
+      id: 'wallet-1',
+      user_id: 'test-user-id',
+      public_key: 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD',
+      balance: 100,
+    }
+    const walletChain = createUserWalletsTableMock(senderRecord, { data: null, error: null })
+
+    const historyChain = createMockChain()
+    historyChain.range = vi.fn(() => historyChain)
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'user_wallets') {
+        return walletChain
+      }
+      if (table === 'echo_rewards') {
+        return historyChain
+      }
+      return createMockChain(null)
+    })
+
+    const user = userEvent.setup()
+    renderWalletPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('100.00 ECHO')).toBeInTheDocument()
+    })
+
+    const recipientInput = screen.getByPlaceholderText(/UUID, email, or G\.\.\. address/i)
+    await user.type(recipientInput, 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+
+    const amountInput = screen.getByPlaceholderText(/Custom amount/i)
+    await user.clear(amountInput)
+    await user.type(amountInput, '10')
+
+    await user.click(screen.getByRole('button', { name: /Send 10 ECHO/i }))
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Address not found/i).length).toBeGreaterThan(0)
+    })
+  })
+
+  test('shows a network error message when the Stellar address lookup fails', async () => {
+    const senderRecord = {
+      id: 'wallet-1',
+      user_id: 'test-user-id',
+      public_key: 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD',
+      balance: 100,
+    }
+    const walletChain = createUserWalletsTableMock(senderRecord, {
+      data: null,
+      error: { message: 'fetch failed' },
+    })
+
+    const historyChain = createMockChain()
+    historyChain.range = vi.fn(() => historyChain)
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'user_wallets') {
+        return walletChain
+      }
+      if (table === 'echo_rewards') {
+        return historyChain
+      }
+      return createMockChain(null)
+    })
+
+    const user = userEvent.setup()
+    renderWalletPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('100.00 ECHO')).toBeInTheDocument()
+    })
+
+    const recipientInput = screen.getByPlaceholderText(/UUID, email, or G\.\.\. address/i)
+    await user.type(recipientInput, 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+
+    const amountInput = screen.getByPlaceholderText(/Custom amount/i)
+    await user.clear(amountInput)
+    await user.type(amountInput, '10')
+
+    await user.click(screen.getByRole('button', { name: /Send 10 ECHO/i }))
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Network error/i).length).toBeGreaterThan(0)
     })
   })
 
@@ -231,6 +460,22 @@ describe('WalletPage', () => {
     })
 
     vi.unstubAllEnvs()
+  })
+
+  test('shows a prominent testnet warning banner', async () => {
+    const walletChain = createMockChain({
+      id: 'wallet-1',
+      user_id: 'test-user-id',
+      public_key: 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD',
+      balance: 50,
+    })
+    mockFrom.mockReturnValue(walletChain)
+
+    renderWalletPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/You are on Testnet/i)).toBeInTheDocument()
+    })
   })
 
   test('no wallet exists state renders create wallet button', async () => {
@@ -392,6 +637,9 @@ describe('WalletPage', () => {
       return createMockChain(null)
     })
 
+    // userEvent.setup() installs its own clipboard stub on `navigator.clipboard`,
+    // so our mock must be defined after setup() or it gets overwritten.
+    const user = userEvent.setup()
     const writeTextMock = vi.fn(() => Promise.resolve())
     Object.defineProperty(navigator, 'clipboard', {
       value: {
@@ -400,7 +648,6 @@ describe('WalletPage', () => {
       configurable: true,
     })
 
-    const user = userEvent.setup()
     renderWalletPage()
 
     await waitFor(() => {

--- a/frontend/src/features/wallet/wallet-page.tsx
+++ b/frontend/src/features/wallet/wallet-page.tsx
@@ -8,6 +8,7 @@ import type { EchoReward, WalletRecord } from '../../lib/types'
 import { formatDateTime } from '../../lib/date'
 import { TestnetBadge } from '../../components/TestnetBadge'
 import { useWalletBalances } from '../../lib/use-wallet-balances'
+import { isTestnet, stellarConfig } from '../../lib/stellar-config'
 
 const WALLET_PAGE_SIZE = 20
 const PRESET_AMOUNTS = [5, 10, 25, 50]
@@ -110,37 +111,69 @@ async function resolveRecipientId(recipientInput: string): Promise<string> {
   }
 
   if (isValidStellarKey(trimmed)) {
-    const { data, error } = await supabase
-      .from('user_wallets')
-      .select('user_id')
-      .eq('public_key', trimmed)
-      .maybeSingle()
+    let data: { user_id: string } | null = null
+    let lookupFailed = false
 
-    if (!error && data?.user_id) {
+    try {
+      const result = await supabase
+        .from('user_wallets')
+        .select('user_id')
+        .eq('public_key', trimmed)
+        .maybeSingle()
+      data = result.data
+      lookupFailed = Boolean(result.error)
+    } catch {
+      lookupFailed = true
+    }
+
+    if (data?.user_id) {
       return data.user_id as string
     }
 
-    throw new Error('Could not resolve recipient from Stellar address. Use recipient user ID.')
+    if (lookupFailed) {
+      throw new Error('Network error while looking up that Stellar address. Please try again.')
+    }
+
+    throw new Error('Address not found. No wallet is linked to that Stellar address.')
   }
 
   if (!trimmed.includes('@')) {
     throw new Error('Use a valid recipient UUID, email address, or Stellar address.')
   }
 
+  let lookupFailed = false
   const profileTables = ['profiles', 'user_profiles']
   for (const table of profileTables) {
-    const { data, error } = await supabase.from(table).select('id').eq('email', trimmed).maybeSingle()
-    if (!error && data?.id) {
-      return data.id as string
+    try {
+      const { data, error } = await supabase.from(table).select('id').eq('email', trimmed).maybeSingle()
+      if (error) {
+        lookupFailed = true
+        continue
+      }
+      if (data?.id) {
+        return data.id as string
+      }
+    } catch {
+      lookupFailed = true
     }
   }
 
-  const { data: rpcData, error: rpcError } = await supabase.rpc('lookup_user_by_email', {
-    email_input: trimmed,
-  })
+  try {
+    const { data: rpcData, error: rpcError } = await supabase.rpc('lookup_user_by_email', {
+      email_input: trimmed,
+    })
 
-  if (!rpcError && rpcData && typeof rpcData.user_id === 'string') {
-    return rpcData.user_id
+    if (rpcError) {
+      lookupFailed = true
+    } else if (rpcData && typeof rpcData.user_id === 'string') {
+      return rpcData.user_id
+    }
+  } catch {
+    lookupFailed = true
+  }
+
+  if (lookupFailed) {
+    throw new Error('Network error while resolving that email. Please try again.')
   }
 
   throw new Error('Could not resolve recipient from email. Use recipient user ID.')
@@ -189,11 +222,22 @@ async function requestFreighterAccess(): Promise<string> {
   if (!isFreighterInstalled()) {
     throw new Error('FREIGHTER_NOT_INSTALLED')
   }
-  const { requestAccess } = await import('@stellar/freighter-api')
+  const { requestAccess, getNetwork } = await import('@stellar/freighter-api')
   const result = await requestAccess()
   if (result.error) {
     throw new Error(result.error.message ?? 'Freighter connection rejected')
   }
+
+  const network = await getNetwork()
+  if (network.error) {
+    throw new Error(network.error.message ?? 'Could not verify the Freighter network.')
+  }
+  if (network.networkPassphrase !== stellarConfig.networkPassphrase) {
+    throw new Error(
+      `Freighter is set to ${network.network}, but this app requires ${stellarConfig.network}. Switch networks in Freighter and try again.`,
+    )
+  }
+
   return result.address
 }
 
@@ -397,6 +441,16 @@ export function WalletPage() {
     <section className="feature-grid wallet-grid">
       <ConfettiBlast active={showConfetti} />
 
+      {isTestnet ? (
+        <div
+          role="status"
+          className="full-width flex items-center gap-2 rounded-lg border border-amber-300 bg-amber-50 px-4 py-2.5 text-sm font-medium text-amber-900"
+        >
+          <span aria-hidden="true">⚠</span>
+          You are on Testnet — ECHO and XLM here have no real-world value.
+        </div>
+      ) : null}
+
       <article className="card balance-card">
         <div className="card-header">
           <div className="flex items-center gap-2"><h2>ECHO Wallet</h2><TestnetBadge /></div>
@@ -416,7 +470,6 @@ export function WalletPage() {
         ) : walletQuery.data?.exists ? (
           <>
             <p className="balance-number">{walletQuery.data.balance.toFixed(2)} ECHO</p>
-            <p className="muted">Public key: {walletQuery.data.record?.public_key?.slice(0, 14) ?? ""}â€¦</p>
             {publicKey ? (
               <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
                 <p className="muted" style={{ margin: 0 }}>
@@ -438,7 +491,7 @@ export function WalletPage() {
               onClick={() => createWalletMutation.mutate()}
               disabled={createWalletMutation.isPending}
             >
-              {createWalletMutation.isPending ? 'Creatingâ€¦' : 'Create wallet'}
+              {createWalletMutation.isPending ? 'Creating…' : 'Create wallet'}
             </button>
             {createWalletMutation.error ? (
               <p className="error-text">{(createWalletMutation.error as Error).message}</p>
@@ -674,7 +727,7 @@ export function WalletPage() {
 
           <button type="submit" disabled={isSendDisabled}>
             {sendGiftMutation.isPending
-              ? 'Sendingâ€¦'
+              ? 'Sending…'
               : `Send ${Number.isFinite(resolvedAmount) ? resolvedAmount : 0} ECHO`}
           </button>
 

--- a/frontend/src/lib/use-wallet-balances.test.tsx
+++ b/frontend/src/lib/use-wallet-balances.test.tsx
@@ -1,0 +1,67 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useWalletBalances } from './use-wallet-balances'
+import { stellarConfig } from './stellar-config'
+
+const PUBLIC_KEY = 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD'
+
+function renderWithClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return renderHook(() => useWalletBalances(PUBLIC_KEY), {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  })
+}
+
+describe('useWalletBalances', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ balances: [] }),
+        }),
+      ),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('requests balances from the configured Horizon URL, not a hardcoded host', async () => {
+    const { result } = renderWithClient()
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(fetch).toHaveBeenCalledWith(`${stellarConfig.horizonUrl}/accounts/${PUBLIC_KEY}`)
+  })
+
+  it('respects VITE_STELLAR_HORIZON_URL overrides', async () => {
+    vi.stubEnv('VITE_STELLAR_HORIZON_URL', 'https://custom-horizon.example.com')
+    vi.resetModules()
+
+    const { useWalletBalances: useWalletBalancesWithOverride } = await import('./use-wallet-balances')
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useWalletBalancesWithOverride(PUBLIC_KEY), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(fetch).toHaveBeenCalledWith(
+      `https://custom-horizon.example.com/accounts/${PUBLIC_KEY}`,
+    )
+
+    vi.unstubAllEnvs()
+  })
+})

--- a/frontend/src/lib/use-wallet-balances.ts
+++ b/frontend/src/lib/use-wallet-balances.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { stellarConfig } from './stellar-config'
 
 type HorizonBalance = {
   asset_type: string
@@ -14,7 +15,7 @@ export type WalletBalancesResult = {
 }
 
 async function fetchHorizonBalances(publicKey: string): Promise<WalletBalancesResult> {
-  const res = await fetch(`https://horizon-testnet.stellar.org/accounts/${publicKey}`)
+  const res = await fetch(`${stellarConfig.horizonUrl}/accounts/${publicKey}`)
   if (res.status === 404) {
     return { xlm: '0', echo: '0', notFunded: true, fetchedAt: Date.now() }
   }


### PR DESCRIPTION
Closes #425

## Summary
- Enforce the configured Stellar network (`VITE_STELLAR_NETWORK`) on Freighter connect — if the extension is on the wrong network, the connection is now rejected with a clear message instead of silently saving a mismatched address.
- Differentiate network failures from "address not found" in `resolveRecipientId()` for both the Stellar-address and email lookup paths, instead of collapsing every failure into one generic message.
- Fix `use-wallet-balances.ts`, which hardcoded `https://horizon-testnet.stellar.org` and ignored `VITE_STELLAR_HORIZON_URL` entirely — it now reads from the shared `stellar-config`, so the Horizon URL is actually configurable across dev/preview/prod.
- Fix corrupted `â€¦` mojibake in the "Creating…"/"Sending…" loading labels, and remove a dead/duplicate public-key paragraph that the mojibake lived in (the properly formatted public-key block with the Copy button already covers that case).
- Add a prominent "You are on Testnet" warning banner above the wallet cards, in addition to the existing small TESTNET badge.
- Fixed a pre-existing broken test (`copy wallet address button works correctly`): `userEvent.setup()` installs its own clipboard stub on `navigator.clipboard`, which was silently overwriting the test's clipboard mock when the mock was defined before `setup()`.
- Added test coverage for: Freighter network-mismatch rejection, user-rejected Freighter connection requests, successful Freighter connection, Stellar-address "not found" vs "network error" differentiation, the testnet banner, and the configurable Horizon URL.

## Test plan
- [x] `npx vitest run` for the wallet feature and `lib` tests — all pass (`wallet-page.test.tsx`: 18 tests, `use-wallet-balances.test.tsx`: 2 tests)
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run build` — succeeds
- [ ] Manual check in a browser with the Freighter extension installed on testnet vs. mainnet