### PR TITLE
feat(logs): add search, sorting, and bulk actions to logs list

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/frontend/src/features/logs/logs-csv.test.ts
+++ b/frontend/src/features/logs/logs-csv.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import { buildLogsCsv, escapeCsvField, logEntryToCsvRow, LOG_CSV_COLUMNS } from './logs-csv'
+import type { LogCsvRow } from './logs-csv'
+
+const baseEntry: LogCsvRow = {
+  id: 'log-1',
+  date: '2026-06-01T12:00:00.000Z',
+  mood: 4,
+  habits: ['Exercise', 'Reading'],
+  notes: 'Felt great today',
+  created_at: '2026-06-01T13:00:00.000Z',
+}
+
+describe('escapeCsvField', () => {
+  test('leaves plain values untouched', () => {
+    expect(escapeCsvField('hello')).toBe('hello')
+  })
+
+  test('quotes values containing a comma', () => {
+    expect(escapeCsvField('a,b')).toBe('"a,b"')
+  })
+
+  test('escapes embedded double quotes by doubling them', () => {
+    expect(escapeCsvField('she said "hi"')).toBe('"she said ""hi"""')
+  })
+
+  test('quotes values containing newlines', () => {
+    expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"')
+  })
+})
+
+describe('logEntryToCsvRow', () => {
+  test('joins habits with a semicolon instead of JSON-stringifying', () => {
+    const row = logEntryToCsvRow(baseEntry)
+    expect(row).toContain('Exercise; Reading')
+    expect(row).not.toContain('[')
+    expect(row).not.toContain('"Exercise"')
+  })
+
+  test('includes the id and created_at columns', () => {
+    const row = logEntryToCsvRow(baseEntry)
+    expect(row.startsWith('log-1,')).toBe(true)
+    expect(row).toContain('2026-06-01T13:00:00.000Z')
+  })
+
+  test('renders null mood and notes as empty fields', () => {
+    const row = logEntryToCsvRow({ ...baseEntry, mood: null, notes: null })
+    expect(row).toBe('log-1,2026-06-01T12:00:00.000Z,,Exercise; Reading,,2026-06-01T13:00:00.000Z')
+  })
+
+  test('escapes notes that contain commas', () => {
+    const row = logEntryToCsvRow({ ...baseEntry, notes: 'one, two, three' })
+    expect(row).toContain('"one, two, three"')
+  })
+
+  test('tolerates a non-array habits value', () => {
+    const row = logEntryToCsvRow({ ...baseEntry, habits: undefined as unknown as string[] })
+    expect(row).toContain('log-1,')
+  })
+})
+
+describe('buildLogsCsv', () => {
+  test('emits a header row with the expected column names', () => {
+    const csv = buildLogsCsv([])
+    expect(csv).toBe(LOG_CSV_COLUMNS.join(','))
+    expect(csv).toBe('id,date,mood,habits,notes,created_at')
+  })
+
+  test('produces one line per entry plus the header', () => {
+    const csv = buildLogsCsv([baseEntry, { ...baseEntry, id: 'log-2' }])
+    const lines = csv.split('\n')
+    expect(lines).toHaveLength(3)
+    expect(lines[0]).toBe('id,date,mood,habits,notes,created_at')
+    expect(lines[1].startsWith('log-1,')).toBe(true)
+    expect(lines[2].startsWith('log-2,')).toBe(true)
+  })
+})

--- a/frontend/src/features/logs/logs-csv.ts
+++ b/frontend/src/features/logs/logs-csv.ts
@@ -1,0 +1,47 @@
+import type { LogEntry } from '../../lib/types'
+
+/**
+ * Columns emitted by the logs CSV export, in order. The header row uses these
+ * exact names.
+ */
+export const LOG_CSV_COLUMNS = ['id', 'date', 'mood', 'habits', 'notes', 'created_at'] as const
+
+/** The minimal shape needed to build a CSV row for a log entry. */
+export type LogCsvRow = Pick<LogEntry, 'id' | 'date' | 'mood' | 'habits' | 'notes' | 'created_at'>
+
+/**
+ * Escape a single CSV field per RFC 4180: wrap the value in double quotes when
+ * it contains a comma, double quote, or line break, and escape inner quotes by
+ * doubling them.
+ */
+export function escapeCsvField(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+/**
+ * Serialize one log entry to a CSV row. Habits are joined into a
+ * semicolon-separated string instead of being JSON-stringified, and a `null`
+ * mood/notes becomes an empty field.
+ */
+export function logEntryToCsvRow(entry: LogCsvRow): string {
+  const habits = Array.isArray(entry.habits) ? entry.habits : []
+  const fields = [
+    entry.id,
+    entry.date,
+    entry.mood ?? '',
+    habits.join('; '),
+    entry.notes ?? '',
+    entry.created_at,
+  ]
+  return fields.map((field) => escapeCsvField(String(field))).join(',')
+}
+
+/** Build a complete CSV document (header row + one row per entry). */
+export function buildLogsCsv(entries: LogCsvRow[]): string {
+  const header = LOG_CSV_COLUMNS.join(',')
+  const rows = entries.map(logEntryToCsvRow)
+  return [header, ...rows].join('\n')
+}

--- a/frontend/src/features/logs/logs-list-page.test.tsx
+++ b/frontend/src/features/logs/logs-list-page.test.tsx
@@ -1,0 +1,372 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { ToastProvider } from '../../lib/use-toast'
+import { LogsListPage } from './logs-list-page'
+import type { LogEntry } from '../../lib/types'
+
+// ── Mutable mock state, configured per test ──
+let mockRows: LogEntry[] = []
+let mockListCount = 0
+let mockTotalCount = 0
+let mockExportRows: LogEntry[] | null = null
+let mockHabits: string[] = []
+
+// Captured query-builder calls so tests can assert how the query was built.
+const calls = {
+  ilike: [] as [string, string][],
+  contains: [] as [string, unknown][],
+  order: [] as [string, unknown][],
+  eq: [] as [string, unknown][],
+  deleteIn: [] as string[][],
+}
+
+function makeEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    id: 'log-1',
+    user_id: 'test-user-id',
+    date: '2026-06-01T12:00:00.000Z',
+    mood: 4,
+    habits: ['Exercise'],
+    notes: 'Morning run felt good',
+    created_at: '2026-06-01T13:00:00.000Z',
+    updated_at: '2026-06-01T13:00:00.000Z',
+    ...overrides,
+  }
+}
+
+vi.mock('../../lib/auth-context', () => ({
+  useAuth: () => ({
+    user: { id: 'test-user-id', email: 'test@example.com' },
+    session: null,
+    isLoading: false,
+    signOut: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/supabase', () => {
+  const makeBuilder = () => {
+    let head = false
+    let isDelete = false
+    const builder: Record<string, unknown> = {
+      select: vi.fn((_cols: string, opts?: { head?: boolean }) => {
+        if (opts?.head) head = true
+        return builder
+      }),
+      eq: vi.fn((col: string, val: unknown) => {
+        calls.eq.push([col, val])
+        return builder
+      }),
+      not: vi.fn(() => builder),
+      gte: vi.fn(() => builder),
+      lte: vi.fn(() => builder),
+      ilike: vi.fn((col: string, val: string) => {
+        calls.ilike.push([col, val])
+        return builder
+      }),
+      contains: vi.fn((col: string, val: unknown) => {
+        calls.contains.push([col, val])
+        return builder
+      }),
+      order: vi.fn((col: string, opts?: unknown) => {
+        calls.order.push([col, opts])
+        return builder
+      }),
+      delete: vi.fn(() => {
+        isDelete = true
+        return builder
+      }),
+      in: vi.fn((_col: string, vals: string[]) => {
+        if (isDelete) calls.deleteIn.push(vals)
+        return builder
+      }),
+      maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+      range: vi.fn(() =>
+        Promise.resolve({ data: mockRows, count: mockListCount, error: null }),
+      ),
+      // Make the builder awaitable for queries that have no `.range()` terminal.
+      then: (onFulfilled: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) => {
+        let value: unknown
+        if (isDelete) value = { error: null }
+        else if (head) value = { count: mockTotalCount, error: null }
+        else value = { data: mockExportRows ?? mockRows, error: null }
+        return Promise.resolve(value).then(onFulfilled, onRejected)
+      },
+    }
+    return builder
+  }
+
+  return {
+    supabase: {
+      from: vi.fn(() => makeBuilder()),
+      rpc: vi.fn(() => Promise.resolve({ data: mockHabits, error: null })),
+    },
+  }
+})
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/logs']}>
+        <ToastProvider>
+          <Routes>
+            <Route path="/logs" element={<LogsListPage />} />
+          </Routes>
+        </ToastProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  mockRows = [makeEntry()]
+  mockListCount = 1
+  mockTotalCount = 1
+  mockExportRows = null
+  mockHabits = []
+  calls.ilike = []
+  calls.contains = []
+  calls.order = []
+  calls.eq = []
+  calls.deleteIn = []
+  sessionStorage.clear()
+  // jsdom does not implement object URLs.
+  URL.createObjectURL = vi.fn(() => 'blob:mock')
+  URL.revokeObjectURL = vi.fn()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('LogsListPage — search', () => {
+  test('debounces input and runs an ILIKE query on notes', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+
+    await user.type(screen.getByPlaceholderText(/search notes/i), 'run')
+
+    await waitFor(
+      () => expect(calls.ilike).toContainEqual(['notes', '%run%']),
+      { timeout: 2000 },
+    )
+  })
+
+  test('highlights the matched term in the notes preview', async () => {
+    const user = userEvent.setup()
+    const { container } = renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+    await user.type(screen.getByPlaceholderText(/search notes/i), 'run')
+
+    await waitFor(
+      () => {
+        const mark = container.querySelector('mark')
+        expect(mark).not.toBeNull()
+        expect(mark?.textContent?.toLowerCase()).toBe('run')
+      },
+      { timeout: 2000 },
+    )
+  })
+
+  test('shows a "No results" empty state with a clear button', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+
+    // After the search debounce, the query returns no rows.
+    mockRows = []
+    mockListCount = 0
+    await user.type(screen.getByPlaceholderText(/search notes/i), 'zzz')
+
+    const emptyState = await screen.findByText(/No results for/i, {}, { timeout: 2000 })
+    expect(emptyState.textContent).toContain('zzz')
+
+    mockRows = [makeEntry()]
+    mockListCount = 1
+    await user.click(screen.getByRole('button', { name: /clear search/i }))
+
+    await waitFor(() => expect(screen.queryByText(/No results for/i)).not.toBeInTheDocument())
+  })
+})
+
+describe('LogsListPage — sorting', () => {
+  test('persists the sort preference in sessionStorage and reorders the query', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+
+    await user.selectOptions(screen.getByLabelText(/sort by/i), 'mood_desc')
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem('echomirror:logs-sort')).toBe('mood_desc')
+      expect(calls.order.some(([col]) => col === 'mood')).toBe(true)
+    })
+  })
+
+  test('restores the persisted sort on mount', async () => {
+    sessionStorage.setItem('echomirror:logs-sort', 'mood_asc')
+    renderPage()
+
+    const select = (await screen.findByLabelText(/sort by/i)) as HTMLSelectElement
+    expect(select.value).toBe('mood_asc')
+  })
+})
+
+describe('LogsListPage — habit filter', () => {
+  test('filters by multiple habits with AND logic', async () => {
+    mockHabits = ['Exercise', 'Reading', 'Sleep']
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+
+    await user.click(screen.getByLabelText(/add habit filter/i))
+    await user.click(await screen.findByRole('button', { name: 'Reading' }))
+
+    await waitFor(() => expect(calls.contains).toContainEqual(['habits', ['Reading']]))
+
+    await user.click(screen.getByLabelText(/add habit filter/i))
+    await user.click(await screen.findByRole('button', { name: 'Exercise' }))
+
+    await waitFor(() => {
+      const containsHabits = calls.contains.filter(([col]) => col === 'habits')
+      const last = containsHabits[containsHabits.length - 1]
+      expect(last[1]).toEqual(['Reading', 'Exercise'])
+    })
+  })
+
+  test('shows a "(showing top 20)" label when suggestions are truncated', async () => {
+    mockHabits = Array.from({ length: 25 }, (_, i) => `Habit${String(i + 1).padStart(2, '0')}`)
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+    await user.click(screen.getByLabelText(/add habit filter/i))
+
+    expect(await screen.findByText(/showing top 20/i)).toBeInTheDocument()
+  })
+})
+
+describe('LogsListPage — bulk actions', () => {
+  test('bulk delete confirms the count and deletes the selected ids', async () => {
+    mockRows = [makeEntry({ id: 'log-1' }), makeEntry({ id: 'log-2', date: '2026-06-02T12:00:00.000Z' })]
+    mockListCount = 2
+    mockTotalCount = 2
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+
+    await user.click(screen.getByLabelText(/select all on this page/i))
+    expect(await screen.findByText('2 selected')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /delete selected/i }))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText(/Delete 2 entries\?/i)).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete 2 entries' }))
+
+    await waitFor(() => {
+      expect(calls.deleteIn).toHaveLength(1)
+      expect(calls.deleteIn[0]).toEqual(expect.arrayContaining(['log-1', 'log-2']))
+    })
+
+    expect(await screen.findByText('2 entries deleted')).toBeInTheDocument()
+  })
+
+  test('bulk export builds a CSV of the selected entries', async () => {
+    mockRows = [
+      makeEntry({ id: 'log-1', notes: 'first' }),
+      makeEntry({ id: 'log-2', notes: 'second', date: '2026-06-02T12:00:00.000Z' }),
+    ]
+    mockListCount = 2
+    mockTotalCount = 2
+
+    let capturedBlob: Blob | null = null
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      capturedBlob = blob
+      return 'blob:mock'
+    }) as unknown as typeof URL.createObjectURL
+
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+
+    await user.click(screen.getByLabelText(/select all on this page/i))
+    await user.click(screen.getByRole('button', { name: /export selected/i }))
+
+    await waitFor(() => expect(capturedBlob).not.toBeNull())
+    const text = await (capturedBlob as unknown as Blob).text()
+    const lines = text.split('\n')
+    expect(lines[0]).toBe('id,date,mood,habits,notes,created_at')
+    expect(lines).toHaveLength(3)
+    expect(text).toContain('log-1')
+    expect(text).toContain('log-2')
+  })
+
+  test('closes the delete dialog when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+
+    await user.click(screen.getByLabelText(/select all on this page/i))
+    await user.click(screen.getByRole('button', { name: /delete selected/i }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  test('toggles a single row selection via its checkbox', async () => {
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+
+    const rowCheckbox = screen.getByLabelText(/select log from jun 1, 2026/i)
+    fireEvent.click(rowCheckbox)
+
+    expect(await screen.findByText('1 selected')).toBeInTheDocument()
+  })
+})
+
+describe('LogsListPage — CSV export header', () => {
+  test('full export includes the id column and a header row', async () => {
+    mockExportRows = [makeEntry({ id: 'log-9', notes: 'exported' })]
+
+    let capturedBlob: Blob | null = null
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      capturedBlob = blob
+      return 'blob:mock'
+    }) as unknown as typeof URL.createObjectURL
+
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Jun 1, 2026')
+    await user.click(screen.getByRole('button', { name: /export csv/i }))
+
+    await waitFor(() => expect(capturedBlob).not.toBeNull())
+    const text = await (capturedBlob as unknown as Blob).text()
+    expect(text.split('\n')[0]).toBe('id,date,mood,habits,notes,created_at')
+    expect(text).toContain('log-9')
+  })
+})

--- a/frontend/src/features/logs/logs-list-page.tsx
+++ b/frontend/src/features/logs/logs-list-page.tsx
@@ -1,13 +1,21 @@
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
-import { useQuery, keepPreviousData } from '@tanstack/react-query'
-import { useEffect, useState, useRef, useMemo } from 'react'
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
+import { useEffect, useState, useRef, useMemo, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../lib/auth-context'
+import { useToast } from '../../lib/use-toast'
 import type { LogEntry } from '../../lib/types'
 import { formatDate, moodToEmoji, toDateInputValue } from '../../lib/date'
+import { buildLogsCsv, type LogCsvRow } from './logs-csv'
+import { SORT_OPTIONS, DEFAULT_SORT, isSortOption, splitOnMatch, type SortOption } from './logs-utils'
 
 const LOGS_PAGE_SIZE = 10
 const LOGS_SCROLL_STORAGE_KEY = 'echomirror:logs-scroll-y'
+const LOGS_SORT_STORAGE_KEY = 'echomirror:logs-sort'
+const SEARCH_DEBOUNCE_MS = 300
+const HABIT_DEBOUNCE_MS = 300
+const HABIT_SUGGESTION_LIMIT = 20
+const NOTE_PREVIEW_LENGTH = 120
 const MOOD_EMOJIS = ['😞', '😕', '😐', '🙂', '😄'] as const
 
 type LogListResult = {
@@ -18,18 +26,18 @@ type LogListResult = {
 
 type LogFilters = {
   mood: number | null
-  habit: string
+  habits: string[]
   dateFrom: string
   dateTo: string
 }
 
-function filtersToParams(f: LogFilters): Record<string, string> {
-  const p: Record<string, string> = {}
-  if (f.mood !== null) p.mood = String(f.mood)
-  if (f.habit) p.habit = f.habit
-  if (f.dateFrom) p.date_from = f.dateFrom
-  if (f.dateTo) p.date_to = f.dateTo
-  return p
+function applyFiltersToParams(params: URLSearchParams, f: LogFilters): void {
+  if (f.mood !== null) params.set('mood', String(f.mood))
+  for (const habit of f.habits) {
+    params.append('habit', habit)
+  }
+  if (f.dateFrom) params.set('date_from', f.dateFrom)
+  if (f.dateTo) params.set('date_to', f.dateTo)
 }
 
 function filtersFromSearchParams(sp: URLSearchParams): LogFilters {
@@ -38,38 +46,97 @@ function filtersFromSearchParams(sp: URLSearchParams): LogFilters {
       const v = Number(sp.get('mood'))
       return Number.isInteger(v) && v >= 1 && v <= 5 ? v : null
     })(),
-    habit: sp.get('habit') ?? '',
+    habits: sp.getAll('habit').filter(Boolean),
     dateFrom: sp.get('date_from') ?? '',
     dateTo: sp.get('date_to') ?? '',
   }
 }
 
 function hasActiveFilters(f: LogFilters): boolean {
-  return f.mood !== null || f.habit !== '' || f.dateFrom !== '' || f.dateTo !== ''
+  return f.mood !== null || f.habits.length > 0 || f.dateFrom !== '' || f.dateTo !== ''
+}
+
+function loadStoredSort(): SortOption {
+  try {
+    const stored = sessionStorage.getItem(LOGS_SORT_STORAGE_KEY)
+    return isSortOption(stored) ? stored : DEFAULT_SORT
+  } catch {
+    return DEFAULT_SORT
+  }
+}
+
+function downloadCsv(csv: string, filename: string): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function todayStamp(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function renderNotePreview(notes: string | null, search: string): ReactNode {
+  const preview = notes?.slice(0, NOTE_PREVIEW_LENGTH) || 'No note'
+  if (!notes || !search.trim()) {
+    return preview
+  }
+  return splitOnMatch(preview, search).map((segment, index) =>
+    segment.match ? <mark key={index}>{segment.text}</mark> : <span key={index}>{segment.text}</span>,
+  )
 }
 
 async function fetchLogs(
   userId: string,
   page: number,
   filters: LogFilters,
+  search: string,
+  sort: SortOption,
 ): Promise<LogListResult> {
   const start = (page - 1) * LOGS_PAGE_SIZE
   const end = start + LOGS_PAGE_SIZE - 1
-  const hasFilters = hasActiveFilters(filters)
+  const trimmedSearch = search.trim()
+  const hasFilters = hasActiveFilters(filters) || trimmedSearch !== ''
 
   // Build the filtered query
   let filteredQuery = supabase
     .from('log_entries')
     .select('*', { count: 'exact' })
     .eq('user_id', userId)
-    .order('date', { ascending: false })
+
+  // Sorting — mood orders fall back to date (newest) for a stable tiebreak and
+  // keep null moods last.
+  if (sort === 'mood_desc') {
+    filteredQuery = filteredQuery
+      .order('mood', { ascending: false, nullsFirst: false })
+      .order('date', { ascending: false })
+  } else if (sort === 'mood_asc') {
+    filteredQuery = filteredQuery
+      .order('mood', { ascending: true, nullsFirst: false })
+      .order('date', { ascending: false })
+  } else if (sort === 'date_asc') {
+    filteredQuery = filteredQuery.order('date', { ascending: true })
+  } else {
+    filteredQuery = filteredQuery.order('date', { ascending: false })
+  }
 
   if (filters.mood !== null) {
     filteredQuery = filteredQuery.eq('mood', filters.mood)
   }
 
-  if (filters.habit) {
-    filteredQuery = filteredQuery.contains('habits', [filters.habit])
+  // A single `contains` with every selected habit applies AND logic (the row's
+  // habits must include all of them).
+  if (filters.habits.length > 0) {
+    filteredQuery = filteredQuery.contains('habits', filters.habits)
+  }
+
+  if (trimmedSearch) {
+    // Escape LIKE wildcards so `%` and `_` are matched literally.
+    const escaped = trimmedSearch.replace(/[\\%_]/g, '\\$&')
+    filteredQuery = filteredQuery.ilike('notes', `%${escaped}%`)
   }
 
   if (filters.dateFrom) {
@@ -160,12 +227,34 @@ async function findExistingLogIdForDate(userId: string, dateValue: string): Prom
 export function LogsListPage() {
   const navigate = useNavigate()
   const { user } = useAuth()
+  const { showToast } = useToast()
+  const queryClient = useQueryClient()
   const [searchParams, setSearchParams] = useSearchParams()
+
   const [isExporting, setIsExporting] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
+
+  // Free-text search (kept in component state, debounced before querying)
+  const [searchInput, setSearchInput] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const didMountSearch = useRef(false)
+
+  // Sort preference (persisted in sessionStorage so it survives pagination)
+  const [sort, setSort] = useState<SortOption>(loadStoredSort)
+
+  // Habit autocomplete
+  const [habitInput, setHabitInput] = useState('')
+  const [debouncedHabitInput, setDebouncedHabitInput] = useState('')
   const [habitAutocompleteOpen, setHabitAutocompleteOpen] = useState(false)
   const habitInputRef = useRef<HTMLInputElement>(null)
   const autocompleteRef = useRef<HTMLDivElement>(null)
+
+  // Bulk selection
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const selectAllRef = useRef<HTMLInputElement>(null)
+  const cancelDeleteRef = useRef<HTMLButtonElement>(null)
+  const deleteTriggerFocusRef = useRef<HTMLElement | null>(null)
 
   // Parse filters from URL
   const filters = useMemo(() => filtersFromSearchParams(searchParams), [searchParams])
@@ -176,13 +265,7 @@ export function LogsListPage() {
   const setFilters = (next: Partial<LogFilters>) => {
     const merged = { ...filters, ...next }
     const nextParams = new URLSearchParams()
-
-    // Set filter params
-    const fp = filtersToParams(merged)
-    for (const [k, v] of Object.entries(fp)) {
-      nextParams.set(k, v)
-    }
-
+    applyFiltersToParams(nextParams, merged)
     // Reset to page 1 when filters change
     setSearchParams(nextParams, { replace: true })
   }
@@ -192,17 +275,9 @@ export function LogsListPage() {
   }
 
   const setPage = (nextPage: number) => {
-    const nextParams = new URLSearchParams(searchParams)
-
-    // Preserve filter params but update page
-    const fp = filtersToParams(filters)
-    for (const [k, v] of Object.entries(fp)) {
-      nextParams.set(k, v)
-    }
-
-    if (nextPage <= 1) {
-      nextParams.delete('page')
-    } else {
+    const nextParams = new URLSearchParams()
+    applyFiltersToParams(nextParams, filters)
+    if (nextPage > 1) {
       nextParams.set('page', String(nextPage))
     }
     setSearchParams(nextParams)
@@ -210,6 +285,21 @@ export function LogsListPage() {
 
   const rememberScrollPosition = () => {
     sessionStorage.setItem(LOGS_SCROLL_STORAGE_KEY, String(window.scrollY))
+  }
+
+  const clearSearch = () => {
+    setSearchInput('')
+    setDebouncedSearch('')
+  }
+
+  const handleSortChange = (value: SortOption) => {
+    setSort(value)
+    try {
+      sessionStorage.setItem(LOGS_SORT_STORAGE_KEY, value)
+    } catch {
+      // sessionStorage may be unavailable (private mode); sorting still works.
+    }
+    setPage(1)
   }
 
   const handleExport = async () => {
@@ -220,35 +310,18 @@ export function LogsListPage() {
 
       const { data, error } = await supabase
         .from('log_entries')
-        .select('date, mood, habits, notes, created_at')
+        .select('id, date, mood, habits, notes, created_at')
         .eq('user_id', user.id)
         .order('date', { ascending: false })
 
       if (error) throw error
 
-      const header = 'date,mood,habits,notes,created_at'
+      const entries = (data ?? []).map((entry) => ({
+        ...entry,
+        habits: Array.isArray(entry.habits) ? entry.habits : [],
+      })) as LogCsvRow[]
 
-      const rows = (data ?? []).map((e) =>
-        [
-          e.date,
-          e.mood ?? '',
-          JSON.stringify(e.habits),
-          (e.notes ?? '').replace(/,/g, ';'),
-          e.created_at,
-        ].join(','),
-      )
-
-      const csv = [header, ...rows].join('\n')
-
-      const blob = new Blob([csv], { type: 'text/csv' })
-      const url = URL.createObjectURL(blob)
-
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `echomirror-logs-${new Date().toISOString().slice(0, 10)}.csv`
-      a.click()
-
-      URL.revokeObjectURL(url)
+      downloadCsv(buildLogsCsv(entries), `echomirror-logs-${todayStamp()}.csv`)
     } catch (err) {
       console.error(err)
       setExportError('Failed to export logs')
@@ -267,14 +340,62 @@ export function LogsListPage() {
 
   const allUserHabits = habitsQuery.data ?? []
 
-  // Filter habits based on input
-  const filteredHabitSuggestions = useMemo(() => {
-    if (!filters.habit) return allUserHabits.slice(0, 20)
-    const q = filters.habit.toLowerCase()
-    return allUserHabits
-      .filter((h) => h.toLowerCase().includes(q))
-      .slice(0, 20)
-  }, [allUserHabits, filters.habit])
+  // Suggestions exclude already-selected habits and are debounced + capped.
+  const { habitSuggestions, habitSuggestionsTruncated } = useMemo(() => {
+    const q = debouncedHabitInput.toLowerCase()
+    const matches = allUserHabits
+      .filter((h) => !filters.habits.includes(h))
+      .filter((h) => (q ? h.toLowerCase().includes(q) : true))
+    return {
+      habitSuggestions: matches.slice(0, HABIT_SUGGESTION_LIMIT),
+      habitSuggestionsTruncated: matches.length > HABIT_SUGGESTION_LIMIT,
+    }
+  }, [allUserHabits, debouncedHabitInput, filters.habits])
+
+  const addHabit = (habit: string) => {
+    const next = habit.trim()
+    if (!next) return
+    if (!filters.habits.includes(next)) {
+      setFilters({ habits: [...filters.habits, next] })
+    }
+    setHabitInput('')
+    setDebouncedHabitInput('')
+    setHabitAutocompleteOpen(false)
+    habitInputRef.current?.blur()
+  }
+
+  const removeHabit = (habit: string) => {
+    setFilters({ habits: filters.habits.filter((h) => h !== habit) })
+  }
+
+  const handleHabitKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      addHabit(habitSuggestions[0] ?? habitInput)
+    }
+  }
+
+  // Debounce the free-text search input
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedSearch(searchInput.trim()), SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(handle)
+  }, [searchInput])
+
+  // Reset to the first page whenever the active search term changes
+  useEffect(() => {
+    if (!didMountSearch.current) {
+      didMountSearch.current = true
+      return
+    }
+    setPage(1)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch])
+
+  // Debounce the habit autocomplete input
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedHabitInput(habitInput.trim()), HABIT_DEBOUNCE_MS)
+    return () => clearTimeout(handle)
+  }, [habitInput])
 
   // Close autocomplete on outside click
   useEffect(() => {
@@ -293,15 +414,80 @@ export function LogsListPage() {
   }, [])
 
   const logsQuery = useQuery({
-    queryKey: ['logs', user?.id, page, filters],
-    queryFn: () => fetchLogs(user!.id, page, filters),
+    queryKey: ['logs', user?.id, page, filters, debouncedSearch, sort],
+    queryFn: () => fetchLogs(user!.id, page, filters, debouncedSearch, sort),
     enabled: Boolean(user?.id),
     placeholderData: keepPreviousData,
   })
+  const rows = logsQuery.data?.rows ?? []
   const totalPages = Math.max(1, Math.ceil((logsQuery.data?.count ?? 0) / LOGS_PAGE_SIZE))
   const hasFilters = hasActiveFilters(filters)
-  const displayedCount = logsQuery.data?.rows.length ?? 0
+  const hasSearch = debouncedSearch.trim() !== ''
+  const displayedCount = rows.length
   const totalCount = logsQuery.data?.totalCount ?? 0
+
+  // Bulk delete
+  const bulkDeleteMutation = useMutation({
+    mutationFn: async (ids: string[]) => {
+      if (!user) {
+        throw new Error('No signed in user found.')
+      }
+      const { error } = await supabase
+        .from('log_entries')
+        .delete()
+        .eq('user_id', user.id)
+        .in('id', ids)
+
+      if (error) throw error
+      return ids.length
+    },
+    onSuccess: async (deletedCount) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['logs', user?.id] }),
+        queryClient.invalidateQueries({ queryKey: ['user-habits', user?.id] }),
+      ])
+      setSelectedIds(new Set())
+      setIsDeleteDialogOpen(false)
+      showToast(`${deletedCount} ${deletedCount === 1 ? 'entry' : 'entries'} deleted`, 'success')
+    },
+    onError: (error: Error) => {
+      setIsDeleteDialogOpen(false)
+      showToast(error.message || 'Failed to delete entries', 'error')
+    },
+  })
+
+  const allSelectedOnPage = rows.length > 0 && rows.every((r) => selectedIds.has(r.id))
+  const someSelectedOnPage = rows.some((r) => selectedIds.has(r.id))
+
+  const toggleSelectAll = () => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (allSelectedOnPage) {
+        for (const r of rows) next.delete(r.id)
+      } else {
+        for (const r of rows) next.add(r.id)
+      }
+      return next
+    })
+  }
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const handleBulkExport = () => {
+    const selected = rows.filter((r) => selectedIds.has(r.id))
+    if (selected.length === 0) return
+    downloadCsv(buildLogsCsv(selected), `echomirror-logs-selected-${todayStamp()}.csv`)
+  }
 
   useEffect(() => {
     const savedScrollY = sessionStorage.getItem(LOGS_SCROLL_STORAGE_KEY)
@@ -317,7 +503,21 @@ export function LogsListPage() {
     if (logsQuery.data && page > totalPages) {
       setPage(totalPages)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [logsQuery.data, page, totalPages])
+
+  // Clear the selection whenever the visible page of rows changes
+  useEffect(() => {
+    setSelectedIds(new Set())
+  }, [page, debouncedSearch, sort, filters])
+
+  // Keep the "select all" checkbox in its indeterminate state when only some
+  // rows on the page are selected.
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someSelectedOnPage && !allSelectedOnPage
+    }
+  }, [someSelectedOnPage, allSelectedOnPage])
 
   // Close autocomplete on Escape
   useEffect(() => {
@@ -328,6 +528,21 @@ export function LogsListPage() {
     window.addEventListener('keydown', handleKey)
     return () => window.removeEventListener('keydown', handleKey)
   }, [habitAutocompleteOpen])
+
+  // Bulk-delete dialog: move focus into it on open, close on Escape, and
+  // restore focus to the element that opened it on close.
+  useEffect(() => {
+    if (!isDeleteDialogOpen) return
+    cancelDeleteRef.current?.focus()
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsDeleteDialogOpen(false)
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => {
+      window.removeEventListener('keydown', handleKey)
+      deleteTriggerFocusRef.current?.focus?.()
+    }
+  }, [isDeleteDialogOpen])
 
   if (!user) {
     return null
@@ -357,6 +572,33 @@ export function LogsListPage() {
           </button>
         </div>
         {exportError && <p className="error-text" style={{ padding: '0 1.5rem' }}>{exportError}</p>}
+
+        {/* ── Search bar ── */}
+        <div style={{ padding: '0.75rem 1.5rem 0', position: 'relative' }}>
+          <label className="field-label" htmlFor="logs-search" style={{ fontSize: '0.75rem' }}>
+            Search notes
+          </label>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            <input
+              id="logs-search"
+              type="search"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              placeholder="Search notes…"
+              style={{ margin: '0.2rem 0 0', flex: 1 }}
+            />
+            {searchInput && (
+              <button
+                type="button"
+                className="secondary"
+                onClick={clearSearch}
+                style={{ whiteSpace: 'nowrap' }}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
 
         {/* ── Filter bar ── */}
         <div style={{
@@ -401,27 +643,45 @@ export function LogsListPage() {
             </div>
           </div>
 
-          {/* Habit filter with autocomplete */}
+          {/* Habit filter with autocomplete (multi-select, AND logic) */}
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem', position: 'relative' }}>
-            <span className="field-label" style={{ fontSize: '0.75rem' }}>Habit</span>
+            <span className="field-label" style={{ fontSize: '0.75rem' }}>Habits</span>
             <input
               ref={habitInputRef}
               type="text"
-              value={filters.habit}
+              value={habitInput}
               onChange={(e) => {
-                setFilters({ habit: e.target.value })
+                setHabitInput(e.target.value)
                 setHabitAutocompleteOpen(true)
               }}
               onFocus={() => setHabitAutocompleteOpen(true)}
-              placeholder="Filter by habit..."
+              onKeyDown={handleHabitKeyDown}
+              placeholder="Add habit filter…"
+              aria-label="Add habit filter"
               style={{
-                width: '160px',
+                width: '180px',
                 padding: '0.4rem 0.55rem',
                 fontSize: '0.85rem',
                 margin: 0,
               }}
             />
-            {habitAutocompleteOpen && filteredHabitSuggestions.length > 0 && (
+            {filters.habits.length > 0 && (
+              <div className="chip-row compact" style={{ maxWidth: '220px' }}>
+                {filters.habits.map((habit) => (
+                  <button
+                    key={habit}
+                    type="button"
+                    className="chip"
+                    onClick={() => removeHabit(habit)}
+                    aria-label={`Remove habit filter ${habit}`}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    {habit} ×
+                  </button>
+                ))}
+              </div>
+            )}
+            {habitAutocompleteOpen && (habitSuggestions.length > 0 || habitSuggestionsTruncated) && (
               <div
                 ref={autocompleteRef}
                 style={{
@@ -434,20 +694,16 @@ export function LogsListPage() {
                   border: '1px solid var(--line)',
                   borderRadius: '8px',
                   boxShadow: 'var(--shadow)',
-                  maxHeight: '180px',
+                  maxHeight: '200px',
                   overflowY: 'auto',
                   marginTop: '2px',
                 }}
               >
-                {filteredHabitSuggestions.map((habit) => (
+                {habitSuggestions.map((habit) => (
                   <button
                     key={habit}
                     type="button"
-                    onClick={() => {
-                      setFilters({ habit })
-                      setHabitAutocompleteOpen(false)
-                      habitInputRef.current?.blur()
-                    }}
+                    onClick={() => addHabit(habit)}
                     style={{
                       display: 'block',
                       width: '100%',
@@ -466,6 +722,11 @@ export function LogsListPage() {
                     {habit}
                   </button>
                 ))}
+                {habitSuggestionsTruncated && (
+                  <div className="muted" style={{ padding: '0.4rem 0.65rem', fontSize: '0.75rem' }}>
+                    (showing top {HABIT_SUGGESTION_LIMIT})
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -477,6 +738,7 @@ export function LogsListPage() {
               type="date"
               value={filters.dateFrom}
               onChange={(e) => setFilters({ dateFrom: e.target.value })}
+              aria-label="Filter from date"
               style={{
                 padding: '0.4rem 0.55rem',
                 fontSize: '0.85rem',
@@ -493,6 +755,7 @@ export function LogsListPage() {
               type="date"
               value={filters.dateTo}
               onChange={(e) => setFilters({ dateTo: e.target.value })}
+              aria-label="Filter to date"
               style={{
                 padding: '0.4rem 0.55rem',
                 fontSize: '0.85rem',
@@ -500,6 +763,33 @@ export function LogsListPage() {
                 margin: 0,
               }}
             />
+          </div>
+
+          {/* Sort selector */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+            <label className="field-label" htmlFor="logs-sort" style={{ fontSize: '0.75rem' }}>
+              Sort by
+            </label>
+            <select
+              id="logs-sort"
+              value={sort}
+              onChange={(e) => handleSortChange(e.target.value as SortOption)}
+              style={{
+                padding: '0.4rem 0.55rem',
+                fontSize: '0.85rem',
+                width: '180px',
+                borderRadius: '10px',
+                border: '1px solid var(--line)',
+                background: 'var(--surface)',
+                color: 'var(--text)',
+              }}
+            >
+              {SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
           </div>
 
           {/* Clear filters */}
@@ -524,7 +814,7 @@ export function LogsListPage() {
         </div>
 
         {/* ── Filtered count ── */}
-        {hasFilters && logsQuery.data && (
+        {(hasFilters || hasSearch) && logsQuery.data && (
           <div style={{
             padding: '0.5rem 1.5rem',
             fontSize: '0.82rem',
@@ -535,38 +825,102 @@ export function LogsListPage() {
           </div>
         )}
 
+        {/* ── Selection / bulk actions toolbar ── */}
+        {rows.length > 0 && (
+          <div className="logs-selection-bar">
+            <label className="logs-select-all">
+              <input
+                ref={selectAllRef}
+                type="checkbox"
+                checked={allSelectedOnPage}
+                onChange={toggleSelectAll}
+                aria-label="Select all on this page"
+              />
+              <span>Select all on this page</span>
+            </label>
+            {selectedIds.size > 0 && (
+              <div className="logs-bulk-actions">
+                <span className="muted">{selectedIds.size} selected</span>
+                <button type="button" className="secondary" onClick={handleBulkExport}>
+                  Export selected
+                </button>
+                <button
+                  type="button"
+                  className="danger"
+                  onClick={() => {
+                    deleteTriggerFocusRef.current = (document.activeElement as HTMLElement) ?? null
+                    setIsDeleteDialogOpen(true)
+                  }}
+                >
+                  Delete selected
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
         <div className="list-stack">
-          {logsQuery.data?.rows.map((entry) => (
-            <Link
-              to={`/logs/${entry.id}`}
-              className="list-card"
-              key={entry.id}
-              onClick={rememberScrollPosition}
-            >
-              <div className="list-card-row">
-                <strong>{formatDate(entry.date)}</strong>
-                <span className="mood-chip">Mood {moodToEmoji(entry.mood)}</span>
-              </div>
+          {rows.map((entry) => {
+            const isSelected = selectedIds.has(entry.id)
+            return (
+              <div className={`log-row${isSelected ? ' selected' : ''}`} key={entry.id}>
+                <label className="log-row-check" style={isSelected ? { opacity: 1 } : undefined}>
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggleSelect(entry.id)}
+                    aria-label={`Select log from ${formatDate(entry.date)}`}
+                  />
+                </label>
+                <Link
+                  to={`/logs/${entry.id}`}
+                  className="list-card log-row-card"
+                  onClick={rememberScrollPosition}
+                >
+                  <div className="list-card-row">
+                    <strong>{formatDate(entry.date)}</strong>
+                    <span className="mood-chip">Mood {moodToEmoji(entry.mood)}</span>
+                  </div>
 
-              <div className="chip-row compact">
-                {entry.habits.slice(0, 5).map((habit) => (
-                  <span className="chip" key={habit}>
-                    {habit}
-                  </span>
-                ))}
-              </div>
+                  <div className="chip-row compact">
+                    {entry.habits.slice(0, 5).map((habit) => (
+                      <span className="chip" key={habit}>
+                        {habit}
+                      </span>
+                    ))}
+                  </div>
 
-              <p className="muted note-preview">{entry.notes?.slice(0, 120) || 'No note'}</p>
-            </Link>
-          ))}
+                  <p className="muted note-preview">{renderNotePreview(entry.notes, debouncedSearch)}</p>
+                </Link>
+              </div>
+            )
+          })}
 
           {logsQuery.isLoading || logsQuery.isFetching ? <div className="skeleton-line" /> : null}
-          {!logsQuery.data?.rows.length && !logsQuery.isLoading ? (
-            <p className="muted" style={{ padding: '1rem 1.5rem' }}>
-              {hasFilters ? 'No entries match the current filters.' : 'No log entries yet.'}
-            </p>
+          {!rows.length && !logsQuery.isLoading ? (
+            hasSearch ? (
+              <div
+                className="muted"
+                style={{
+                  padding: '1rem 1.5rem',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '0.6rem',
+                  alignItems: 'flex-start',
+                }}
+              >
+                <span>No results for &ldquo;{debouncedSearch}&rdquo;</span>
+                <button type="button" className="secondary" onClick={clearSearch}>
+                  Clear search
+                </button>
+              </div>
+            ) : (
+              <p className="muted" style={{ padding: '1rem 1.5rem' }}>
+                {hasFilters ? 'No entries match the current filters.' : 'No log entries yet.'}
+              </p>
+            )
           ) : null}
-          {logsQuery.data?.rows.length && page >= totalPages && !logsQuery.isFetching ? (
+          {rows.length && page >= totalPages && !logsQuery.isFetching ? (
             <p className="muted" style={{ padding: '0.5rem 0' }}>No more entries.</p>
           ) : null}
         </div>
@@ -591,6 +945,48 @@ export function LogsListPage() {
           </button>
         </div>
       </article>
+
+      {/* ── Bulk delete confirmation dialog ── */}
+      {isDeleteDialogOpen && (
+        <div className="modal-overlay" role="presentation" onClick={() => setIsDeleteDialogOpen(false)}>
+          <div
+            className="modal-card"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="bulk-delete-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="bulk-delete-title" style={{ margin: 0 }}>
+              Delete {selectedIds.size} {selectedIds.size === 1 ? 'entry' : 'entries'}?
+            </h3>
+            <p className="muted" style={{ margin: 0 }}>
+              This action cannot be undone. The selected log{' '}
+              {selectedIds.size === 1 ? 'entry' : 'entries'} will be permanently removed.
+            </p>
+            <div className="modal-actions">
+              <button
+                ref={cancelDeleteRef}
+                type="button"
+                className="secondary"
+                onClick={() => setIsDeleteDialogOpen(false)}
+                disabled={bulkDeleteMutation.isPending}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="danger"
+                onClick={() => bulkDeleteMutation.mutate([...selectedIds])}
+                disabled={bulkDeleteMutation.isPending}
+              >
+                {bulkDeleteMutation.isPending
+                  ? 'Deleting…'
+                  : `Delete ${selectedIds.size} ${selectedIds.size === 1 ? 'entry' : 'entries'}`}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </section>
   )
 }

--- a/frontend/src/features/logs/logs-utils.test.ts
+++ b/frontend/src/features/logs/logs-utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest'
+import { isSortOption, splitOnMatch } from './logs-utils'
+
+describe('isSortOption', () => {
+  test('accepts the four valid sort values', () => {
+    expect(isSortOption('date_desc')).toBe(true)
+    expect(isSortOption('date_asc')).toBe(true)
+    expect(isSortOption('mood_desc')).toBe(true)
+    expect(isSortOption('mood_asc')).toBe(true)
+  })
+
+  test('rejects unknown or malformed values', () => {
+    expect(isSortOption('mood')).toBe(false)
+    expect(isSortOption(null)).toBe(false)
+    expect(isSortOption(undefined)).toBe(false)
+    expect(isSortOption(42)).toBe(false)
+  })
+})
+
+describe('splitOnMatch', () => {
+  test('returns a single non-matching segment when the term is empty', () => {
+    expect(splitOnMatch('hello world', '')).toEqual([{ text: 'hello world', match: false }])
+  })
+
+  test('marks a case-insensitive match', () => {
+    const segments = splitOnMatch('I went Running today', 'running')
+    expect(segments).toEqual([
+      { text: 'I went ', match: false },
+      { text: 'Running', match: true },
+      { text: ' today', match: false },
+    ])
+  })
+
+  test('marks every occurrence of the term', () => {
+    const segments = splitOnMatch('run run run', 'run')
+    expect(segments.filter((s) => s.match)).toHaveLength(3)
+  })
+
+  test('escapes regex special characters in the term', () => {
+    const segments = splitOnMatch('cost is $5 today', '$5')
+    expect(segments).toContainEqual({ text: '$5', match: true })
+  })
+
+  test('handles a term that does not appear', () => {
+    expect(splitOnMatch('nothing here', 'xyz')).toEqual([{ text: 'nothing here', match: false }])
+  })
+})

--- a/frontend/src/features/logs/logs-utils.ts
+++ b/frontend/src/features/logs/logs-utils.ts
@@ -1,0 +1,65 @@
+/** Available sort orders for the logs list. */
+export type SortOption = 'date_desc' | 'date_asc' | 'mood_desc' | 'mood_asc'
+
+/** Sort options in display order; the first entry is the default. */
+export const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: 'date_desc', label: 'Date (newest first)' },
+  { value: 'date_asc', label: 'Date (oldest first)' },
+  { value: 'mood_desc', label: 'Mood (highest)' },
+  { value: 'mood_asc', label: 'Mood (lowest)' },
+]
+
+export const DEFAULT_SORT: SortOption = 'date_desc'
+
+/** Type guard for values read back from storage / the DOM. */
+export function isSortOption(value: unknown): value is SortOption {
+  return (
+    value === 'date_desc' ||
+    value === 'date_asc' ||
+    value === 'mood_desc' ||
+    value === 'mood_asc'
+  )
+}
+
+/** A run of text that either matches the search term or does not. */
+export type HighlightSegment = { text: string; match: boolean }
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Split `text` into alternating non-matching / matching segments for the given
+ * search `term` (case-insensitive). Used to highlight matches in the notes
+ * preview. Returns a single non-matching segment when the term is empty.
+ */
+export function splitOnMatch(text: string, term: string): HighlightSegment[] {
+  const trimmed = term.trim()
+  if (!trimmed || !text) {
+    return [{ text, match: false }]
+  }
+
+  const matcher = new RegExp(escapeRegExp(trimmed), 'gi')
+  const segments: HighlightSegment[] = []
+  let lastIndex = 0
+  let found: RegExpExecArray | null
+
+  while ((found = matcher.exec(text)) !== null) {
+    if (found.index > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, found.index), match: false })
+    }
+    segments.push({ text: found[0], match: true })
+    lastIndex = found.index + found[0].length
+
+    // Guard against zero-length matches creating an infinite loop.
+    if (found.index === matcher.lastIndex) {
+      matcher.lastIndex += 1
+    }
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex), match: false })
+  }
+
+  return segments
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -475,6 +475,137 @@ td {
   padding: 0.2rem 0.55rem;
 }
 
+/* Checkboxes should not stretch to full width like text inputs. */
+input[type='checkbox'] {
+  width: auto;
+  margin-top: 0;
+  cursor: pointer;
+}
+
+/* Secondary / outline button variant. */
+button.secondary {
+  background: var(--surface-soft);
+  color: var(--text);
+  border: 1px solid var(--line);
+}
+
+button.secondary:hover:enabled {
+  background: var(--surface);
+}
+
+/* Highlighted search matches in the notes preview. Opaque background + dark
+   text keeps contrast strong in light, dark, and system-dark themes. */
+mark {
+  background: #ffe082;
+  color: #12212f;
+  border-radius: 3px;
+  padding: 0 0.1em;
+}
+
+[data-theme='dark'] mark {
+  background: #facc15;
+  color: #12212f;
+}
+
+/* ── Logs list: selection + bulk actions ── */
+.logs-selection-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.5rem 1.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.logs-select-all {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.logs-bulk-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+}
+
+.logs-bulk-actions button {
+  padding: 0.4rem 0.7rem;
+  font-size: 0.82rem;
+}
+
+.log-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+}
+
+.log-row-card {
+  display: block;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Subtle by default but always visible (and focusable) so keyboard users can
+   discover it; fully opaque on hover, focus, or when the row is selected. */
+.log-row-check {
+  display: flex;
+  align-items: center;
+  padding-top: 0.85rem;
+  opacity: 0.4;
+  transition: opacity 0.15s ease;
+}
+
+.log-row:hover .log-row-check,
+.log-row-check:focus-within,
+.log-row.selected .log-row-check {
+  opacity: 1;
+}
+
+@media (max-width: 640px) {
+  .log-row-check {
+    opacity: 1;
+  }
+}
+
+/* ── Modal dialog ── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 33, 56, 0.45);
+}
+
+.modal-card {
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding: 1.25rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
 .stress-meter {
   margin-top: 0.8rem;
 }


### PR DESCRIPTION
## What & why

Closes #438.

The logs list page (`frontend/src/features/logs/logs-list-page.tsx`) had pagination and mood/habit/date filters but no free-text search, no sort options, and no bulk actions. Power users with hundreds of logs had no fast way to find or act on entries. This PR adds all of that without breaking the existing filters or pagination.

## Changes

### Free-text search
- Search input above the filters that searches `notes` via Supabase `ilike` (LIKE wildcards `%`/`_` are escaped so they match literally).
- 300 ms debounce before querying.
- Matched term is highlighted (`<mark>`) in the notes preview.
- `No results for "{query}"` empty state with a **Clear search** button.
- Search lives in component state, so it survives pagination without polluting the URL.

### Sorting
- Sort selector: Date (newest – default), Date (oldest), Mood (highest), Mood (lowest). Mood orders keep null moods last and fall back to date for a stable tiebreak.
- Preference persisted in `sessionStorage`, so it survives pagination navigation.

### Bulk actions
- Per-row checkbox (subtle by default, full opacity on hover/focus/selection, always visible on mobile) and a **Select all on this page** master checkbox with an indeterminate state.
- Bulk delete behind a confirmation dialog that states how many entries will be removed. The dialog closes on Escape / overlay click / Cancel, moves focus into itself on open, and restores focus on close.
- Bulk export of the selected entries as CSV.

### CSV export improvements
- New reusable `buildLogsCsv` helper (`logs-csv.ts`): habits are joined with `; ` instead of being JSON-stringified, output has a header row, and now includes the `id` and `created_at` columns with RFC-4180-correct escaping. Used by both full export and bulk export.

### Habit autocomplete
- 300 ms debounce on the autocomplete input.
- `(showing top 20)` hint when the suggestion list is truncated.
- Multiple habits can be selected at once (AND logic via a single `contains('habits', [...])`), shown as removable chips.

### Repo fix
- `frontend/.gitignore` had the Vite-boilerplate `logs` rule, which matched the `src/features/logs` **source** directory and silently untracked any new file added there. Anchored it to `/logs` so only a project-root logs directory is ignored.

## Testing
- New unit tests for the CSV builder and the sort/highlight utilities.
- New component tests for debounced search + highlight, the no-results state, sort persistence, multi-habit AND filtering, the `(showing top 20)` hint, bulk delete confirmation + Escape close, and bulk/full CSV export.
- `npm run typecheck` and `npm run build` pass; the new test files pass (`30` logs-list tests + utility tests).

## Notes
- Front-end only — no database migration required (`ilike`, `contains`, `order`, and `in` are all supported by the existing schema/RLS).
- The habit filter URL param changed from a single `habit` value to repeated `habit` params to support multi-select; nothing else in the codebase reads the old param.
