### PR TITLE
fix(theme): dark mode and light mode visual inconsistencies across all pages

### DIFF
--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '../../lib/auth-context'
 import { supabase } from '../../lib/supabase'
 import { useSearchLogs } from '../../lib/use-search-logs'
-import { useTheme } from '../../lib/use-theme'
+import { useTheme, type Theme } from '../../lib/use-theme'
 import { formatDate, moodToEmoji } from '../../lib/date'
 import { NotificationDrawer } from '../../features/notifications/notification-drawer'
 
@@ -55,7 +55,15 @@ export function AppShell() {
   const [isMobileDrawerOpen, setIsMobileDrawerOpen] = useState(false)
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false)
   const [isNotificationPanelOpen, setIsNotificationPanelOpen] = useState(false)
-  const { resolvedTheme, setTheme } = useTheme()
+  const { theme, setTheme } = useTheme()
+
+  const themeIcon: Record<Theme, string> = { light: '☀️', dark: '🌙', system: '🖥️' }
+  const themeNext: Record<Theme, Theme> = { light: 'dark', dark: 'system', system: 'light' }
+  const themeAriaLabel: Record<Theme, string> = {
+    light: 'Switch to dark mode',
+    dark: 'Switch to system theme',
+    system: 'Switch to light mode',
+  }
 
   // Search state
   const [searchQuery, setSearchQuery] = useState('')
@@ -313,10 +321,11 @@ export function AppShell() {
             <button
               type="button"
               className="icon-btn"
-              aria-label={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-              onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+              aria-label={themeAriaLabel[theme]}
+              title={themeAriaLabel[theme]}
+              onClick={() => setTheme(themeNext[theme])}
             >
-              {resolvedTheme === 'dark' ? '☀️' : '🌙'}
+              {themeIcon[theme]}
             </button>
 
             <div style={{ position: 'relative' }}>

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -8,7 +8,8 @@ import './landing-page.css'
 const features = [
   {
     icon: '🧠',
-    bg: 'linear-gradient(135deg,#dbeafe,#eff6ff)',
+    bg:     'linear-gradient(135deg,#dbeafe,#eff6ff)',
+    bgDark: 'linear-gradient(135deg,rgba(59,130,246,0.18),rgba(59,130,246,0.08))',
     accent: '#1463ff',
     title: 'AI Mood Insights',
     desc: 'Your AI companion surfaces personalised reflections shaped by your history — not generic advice.',
@@ -16,7 +17,8 @@ const features = [
   },
   {
     icon: '🌍',
-    bg: 'linear-gradient(135deg,#d6f8ef,#ecfdf5)',
+    bg:     'linear-gradient(135deg,#d6f8ef,#ecfdf5)',
+    bgDark: 'linear-gradient(135deg,rgba(16,185,129,0.18),rgba(16,185,129,0.08))',
     accent: '#0a8a5b',
     title: 'Global Mirror',
     desc: 'See how your emotional state compares with thousands worldwide, in real time.',
@@ -24,7 +26,8 @@ const features = [
   },
   {
     icon: '📓',
-    bg: 'linear-gradient(135deg,#ede9fe,#f5f3ff)',
+    bg:     'linear-gradient(135deg,#ede9fe,#f5f3ff)',
+    bgDark: 'linear-gradient(135deg,rgba(139,92,246,0.18),rgba(139,92,246,0.08))',
     accent: '#7c3aed',
     title: 'Habit & Mood Logs',
     desc: 'Log what you feel. Over time, patterns emerge you\'d never catch in the moment.',
@@ -32,7 +35,8 @@ const features = [
   },
   {
     icon: '✦',
-    bg: 'linear-gradient(135deg,#fef3c7,#fffbeb)',
+    bg:     'linear-gradient(135deg,#fef3c7,#fffbeb)',
+    bgDark: 'linear-gradient(135deg,rgba(251,191,36,0.18),rgba(251,191,36,0.08))',
     accent: '#d97706',
     title: 'ECHO Wallet',
     desc: 'Earn ECHO tokens on Stellar just by showing up. Consistency has real value here.',
@@ -434,7 +438,7 @@ export function LandingPage() {
             {features.map((f, i) => (
               <Reveal key={f.title} delay={(i % 2) + 1 as 1 | 2}>
                 <div className="lp-feature">
-                  <div className="lp-feature-top" style={{ background: f.bg }}>
+                  <div className="lp-feature-top" style={{ background: resolvedTheme === 'dark' ? f.bgDark : f.bg }}>
                     <div className="lp-feature-icon-wrap">{f.icon}</div>
                     <div className="lp-feature-stat" style={{ color: f.accent }}>{f.stat}</div>
                   </div>

--- a/frontend/src/features/landing/landing-page.css
+++ b/frontend/src/features/landing/landing-page.css
@@ -1877,7 +1877,7 @@ a.lp-cta-ghost:hover { color: rgba(255,255,255,0.8) !important; }
   .lp-auth-hero-body { display: none; }
   .lp-auth-chips { display: none; }
   .lp-auth-right { border-left: none; border-top: 1px solid var(--lp-border); padding: 2rem 1.5rem; background: var(--lp-canvas); }
-  .lp-auth-input { background: white; }
+  .lp-auth-input { background: var(--lp-canvas); }
 }
 
 @media (max-width: 640px) {
@@ -2437,6 +2437,22 @@ a.lp-mobile-menu-link {
 [data-theme='dark'] .lp-auth-input:focus { background: var(--lp-white); }
 [data-theme='dark'] .lp-how-num { background: var(--lp-white); color: var(--lp-ink); }
 
+/* Pin permanently-dark sections: --lp-ink remaps to near-white text in dark mode,
+   so sections that use it as a background colour must be pinned to their dark value. */
+[data-theme='dark'] .lp-hero     { background: #0c1a2e !important; }
+[data-theme='dark'] .lp-cta-section { background: #0c1a2e !important; }
+[data-theme='dark'] .lp-footer   { background: #0c1a2e !important; }
+
+/* Contributor skeleton shimmer */
+[data-theme='dark'] .lp-skel-avatar,
+[data-theme='dark'] .lp-skel-name {
+  background: linear-gradient(90deg, #2d2d3a 25%, #3a3a4a 50%, #2d2d3a 75%);
+  background-size: 200% 100%;
+}
+
+/* Auth input: responsive block hardcodes white; use the canvas variable instead */
+[data-theme='dark'] .lp-auth-input { background: var(--lp-canvas); }
+
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme='light']) .lp-root {
     --lp-canvas: #0f0f13;
@@ -2454,4 +2470,16 @@ a.lp-mobile-menu-link {
   :root:not([data-theme='light']) .lp-hero-cta-secondary { background: var(--lp-white); color: var(--lp-ink); }
   :root:not([data-theme='light']) .lp-auth-input:focus { background: var(--lp-white); }
   :root:not([data-theme='light']) .lp-how-num { background: var(--lp-white); color: var(--lp-ink); }
+
+  :root:not([data-theme='light']) .lp-hero     { background: #0c1a2e !important; }
+  :root:not([data-theme='light']) .lp-cta-section { background: #0c1a2e !important; }
+  :root:not([data-theme='light']) .lp-footer   { background: #0c1a2e !important; }
+
+  :root:not([data-theme='light']) .lp-skel-avatar,
+  :root:not([data-theme='light']) .lp-skel-name {
+    background: linear-gradient(90deg, #2d2d3a 25%, #3a3a4a 50%, #2d2d3a 75%);
+    background-size: 200% 100%;
+  }
+
+  :root:not([data-theme='light']) .lp-auth-input { background: var(--lp-canvas); }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1049,6 +1049,74 @@ td {
   padding: 1rem;
 }
 
+/* ── Search dropdown ──────────────────────────────────────── */
+.search-dropdown {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  margin-top: 0.35rem;
+  overflow: hidden;
+}
+
+.search-empty {
+  padding: 0.75rem 1rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.search-results {
+  display: flex;
+  flex-direction: column;
+}
+
+.search-result {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  color: var(--text);
+  padding: 0.55rem 0.85rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--line);
+  transform: none;
+}
+
+.search-result:last-child {
+  border-bottom: none;
+}
+
+.search-result:hover:enabled,
+.search-result.focused {
+  background: var(--surface-soft);
+  transform: none;
+}
+
+.result-date {
+  color: var(--muted);
+  font-size: 0.8rem;
+  min-width: 80px;
+  flex-shrink: 0;
+}
+
+.result-mood {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.result-notes {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .placeholder-page {
   min-height: 220px;
   display: grid;


### PR DESCRIPTION
## Summary

Fixes visual inconsistencies across landing page and app shell in both dark and light mode.

- **Landing page hero / CTA / footer backgrounds**: `--lp-ink` is remapped to near-white (`#f3f4f6`) in dark mode to serve as text colour, but `.lp-hero`, `.lp-cta-section`, and `.lp-footer` all use `background: var(--lp-ink)`. This caused those permanently-dark sections to turn near-white, making all white text invisible. Fixed by pinning their backgrounds to `#0c1a2e !important` in both the `[data-theme='dark']` and `prefers-color-scheme: dark` blocks.
- **Feature card top-section gradients**: The four `.lp-feature-top` areas had hardcoded light-pastel inline gradients (`#dbeafe`, `#d6f8ef`, `#ede9fe`, `#fef3c7`) that clash with dark card backgrounds. Added `bgDark` semi-transparent variants to the features array and switched the inline style to read `resolvedTheme` so each card uses the appropriate gradient.
- **Contributor skeleton shimmer**: `.lp-skel-avatar` and `.lp-skel-name` used hardcoded light shimmer colours (`#e8edf5`, `#f3f6fc`). Added dark-mode overrides to use the existing dark surface tones.
- **Mobile auth input hardcoded `white`**: The `@media (max-width: 1024px)` block overrode `.lp-auth-input` with `background: white`. Replaced with `var(--lp-canvas)` so it adapts to the active theme.
- **Missing search-dropdown styles**: `.search-dropdown`, `.search-result`, `.result-date`, `.result-mood`, `.result-notes`, etc. had no CSS at all — the topbar search UI was completely unstyled. Added all classes using CSS custom properties so dark mode is handled automatically.
- **3-way theme toggle**: The existing topbar button only cycled between `light` and `dark`, making it impossible to return to `system` (OS-preference) mode. Upgraded to a 3-way cycle: **light → dark → system → light**, with matching icons (☀️ / 🌙 / 🖥️) and aria-labels. `useTheme` already persists `system` to localStorage.

## Test plan

- [ ] Toggle theme to **dark** on the landing page and verify hero, CTA ("Your reflection is waiting"), and footer sections remain dark with readable white text
- [ ] Verify the four feature cards show dark semi-transparent tinted backgrounds (not light pastels) in dark mode
- [ ] Verify contributor skeleton uses dark shimmer, not white flashes
- [ ] In the logged-in app, confirm the search bar dropdown renders a styled card (not bare white) in both light and dark mode
- [ ] Click the theme toggle button repeatedly and confirm it cycles ☀️ → 🌙 → 🖥️ → ☀️, with the page actually switching theme on each click
- [ ] Reload after selecting "system" (🖥️) and confirm the OS preference is applied

Closes #427