### PR TITLE
feat(web/auth): add password strength indicator to signup form

### DIFF
--- a/frontend/src/features/auth/pages/SignupPage.tsx
+++ b/frontend/src/features/auth/pages/SignupPage.tsx
@@ -3,6 +3,16 @@ import { useNavigate, Link } from 'react-router-dom'
 import { supabase } from '../../../lib/supabase'
 import '../../landing/landing-page.css'
 
+function getPasswordStrength(password: string): { score: number; label: string } {
+  if (password.length < 8) return { score: 0, label: 'Weak' }
+  const hasLetter = /[a-zA-Z]/.test(password)
+  const hasNumber = /[0-9]/.test(password)
+  const hasSymbol = /[^a-zA-Z0-9]/.test(password)
+  const types = [hasLetter, hasNumber, hasSymbol].filter(Boolean).length
+  if (types >= 2) return { score: 2, label: 'Strong' }
+  return { score: 1, label: 'Fair' }
+}
+
 export function SignupPage() {
   const navigate = useNavigate()
   const [name, setName] = useState('')
@@ -87,6 +97,12 @@ export function SignupPage() {
               <label className="lp-auth-label" htmlFor="su-pass">Password</label>
               <input id="su-pass" className="lp-auth-input" type="password" required
                 value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Min. 6 characters" autoComplete="new-password" />
+              {password.length > 0 && (
+                <div className="ps-bar">
+                  <div className="ps-bar-fill" data-strength={['weak', 'fair', 'strong'][getPasswordStrength(password).score]} style={{ width: `${((getPasswordStrength(password).score + 1) / 3) * 100}%` }} />
+                  <span className="ps-label" data-strength={['weak', 'fair', 'strong'][getPasswordStrength(password).score]}>{getPasswordStrength(password).label}</span>
+                </div>
+              )}
             </div>
 
             {error && <div className="lp-auth-error">{error}</div>}

--- a/frontend/src/features/landing/landing-page.css
+++ b/frontend/src/features/landing/landing-page.css
@@ -1267,6 +1267,37 @@ a.lp-cta-ghost:hover { color: rgba(255,255,255,0.8) !important; }
   box-shadow: 0 0 0 3px rgba(20, 99, 255, 0.1);
 }
 
+/* ── Password strength bar ────────────────────────────── */
+.ps-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 4px;
+  margin-top: 0.2rem;
+}
+
+.ps-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.2s ease, background 0.2s ease;
+}
+
+.ps-bar-fill[data-strength='weak']   { background: #ef4444; }
+.ps-bar-fill[data-strength='fair']   { background: #f59e0b; }
+.ps-bar-fill[data-strength='strong'] { background: #22c55e; }
+
+.ps-label {
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  transition: color 0.2s ease;
+}
+
+.ps-label[data-strength='weak']   { color: #ef4444; }
+.ps-label[data-strength='fair']   { color: #f59e0b; }
+.ps-label[data-strength='strong'] { color: #22c55e; }
+
 .lp-auth-submit {
   width: 100%;
   margin-top: 0.25rem;


### PR DESCRIPTION
## feat : add password strength indicator to signup form
Adds a real-time password strength bar below the password field on /signup.
Closes #414
Closes #415 
Closes #416 
Closes #417 

### Changes

- frontend/src/features/auth/pages/SignupPage.tsx â€” added getPasswordStrength helper and strength bar UI
- frontend/src/features/landing/landing-page.css â€” styles for the bar and label

### How it works

- Weak (red, 33% width) - under 8 characters
- Fair (amber, 66% width) - 8+ chars with only letters or only numbers
- Strong (green, 100% width) - 8+ chars with a mix of letters, numbers, or symbols
- Bar is hidden when the password field is empty; appears as soon as the user starts typing
- Pure CSS + inline helper - no external dependencies
- 