### PR TITLE
feat(web/flutter): habit×mood heatmap, PDF export, remember-me, profile

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,8 @@
         "@stellar/freighter-api": "^6.0.1",
         "@supabase/supabase-js": "^2.104.1",
         "@tanstack/react-query": "^5.100.5",
+        "html-to-image": "^1.11.13",
+        "jspdf": "^4.2.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.2",
@@ -97,7 +99,6 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -113,7 +114,6 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -228,6 +228,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -276,33 +277,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -312,7 +289,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -918,8 +894,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1009,12 +984,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1025,9 +1014,17 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -1174,7 +1171,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1185,7 +1181,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1248,6 +1243,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {
@@ -1313,6 +1318,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1372,6 +1378,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1409,6 +1435,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -1611,8 +1659,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -1622,6 +1669,16 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1696,6 +1753,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1713,6 +1781,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
@@ -1754,6 +1828,26 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/iceberg-js": {
@@ -1804,6 +1898,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -1823,6 +1923,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -1856,6 +1957,23 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/lightningcss": {
@@ -2153,7 +2271,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -2234,6 +2351,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -2254,6 +2387,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2267,6 +2407,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2341,6 +2482,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -2363,7 +2505,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2400,11 +2541,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2414,6 +2566,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2426,8 +2579,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-router": {
       "version": "7.15.1",
@@ -2551,6 +2703,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2559,6 +2718,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rolldown": {
@@ -2656,6 +2825,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -2676,6 +2855,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -2689,6 +2878,16 @@
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -2847,6 +3046,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
       "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
@@ -2875,6 +3084,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "@stellar/freighter-api": "^6.0.1",
     "@supabase/supabase-js": "^2.104.1",
     "@tanstack/react-query": "^5.100.5",
+    "html-to-image": "^1.11.13",
+    "jspdf": "^4.2.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.2",

--- a/frontend/src/features/analytics/analytics-helpers.ts
+++ b/frontend/src/features/analytics/analytics-helpers.ts
@@ -84,3 +84,30 @@ export function buildHabitFrequency(entries: AnalyticsLogEntry[]): { habit: stri
 export function buildStreakDays(entries: AnalyticsLogEntry[]): Set<string> {
   return new Set(entries.map((e) => e.date.slice(0, 10)))
 }
+
+export type HeatmapRow = { habit: string; counts: Record<number, number> }
+
+export function buildHabitMoodHeatmap(entries: AnalyticsLogEntry[]): HeatmapRow[] {
+  const freq: Record<string, number> = {}
+  for (const e of entries) {
+    for (const h of e.habits ?? []) freq[h] = (freq[h] ?? 0) + 1
+  }
+  const topHabits = Object.entries(freq)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([h]) => h)
+
+  if (topHabits.length === 0) return []
+
+  const grid: Record<string, Record<number, number>> = {}
+  for (const h of topHabits) grid[h] = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+
+  for (const e of entries) {
+    if (e.mood == null) continue
+    for (const h of e.habits ?? []) {
+      if (grid[h]) grid[h][e.mood] = (grid[h][e.mood] ?? 0) + 1
+    }
+  }
+
+  return topHabits.map((h) => ({ habit: h, counts: grid[h] }))
+}

--- a/frontend/src/features/analytics/analytics-page.test.tsx
+++ b/frontend/src/features/analytics/analytics-page.test.tsx
@@ -30,6 +30,7 @@ vi.mock('../../lib/supabase', () => ({
 import {
   buildHabitCorrelation,
   buildHabitFrequency,
+  buildHabitMoodHeatmap,
   fetchEntries,
 } from './analytics-helpers'
 
@@ -120,5 +121,82 @@ describe('analytics page data helpers', () => {
       { habit: 'sleep', count: 1 },
       { habit: 'exercise', count: 1 },
     ])
+  })
+})
+
+describe('buildHabitMoodHeatmap', () => {
+  const makeEntry = (
+    mood: number | null,
+    habits: string[] | null,
+  ) => ({
+    id: 'x',
+    user_id: 'u',
+    date: '2024-01-01',
+    mood,
+    habits,
+    notes: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  })
+
+  it('returns empty array for no entries', () => {
+    expect(buildHabitMoodHeatmap([])).toEqual([])
+  })
+
+  it('returns empty array when all habits are null', () => {
+    expect(buildHabitMoodHeatmap([makeEntry(3, null)] as any)).toEqual([])
+  })
+
+  it('counts a single habit + single mood correctly', () => {
+    const entries = [makeEntry(4, ['exercise']), makeEntry(4, ['exercise'])]
+    const result = buildHabitMoodHeatmap(entries as any)
+    expect(result).toHaveLength(1)
+    expect(result[0].habit).toBe('exercise')
+    expect(result[0].counts[4]).toBe(2)
+    expect(result[0].counts[1]).toBe(0)
+    expect(result[0].counts[5]).toBe(0)
+  })
+
+  it('skips entries with null mood', () => {
+    const entries = [makeEntry(null, ['walk']), makeEntry(3, ['walk'])]
+    const result = buildHabitMoodHeatmap(entries as any)
+    expect(result[0].counts[3]).toBe(1)
+    // null mood entries should not increment any score
+    expect(Object.values(result[0].counts).reduce((a, b) => a + b, 0)).toBe(1)
+  })
+
+  it('handles null habits without throwing', () => {
+    const entries = [makeEntry(3, null), makeEntry(4, ['run'])]
+    expect(() => buildHabitMoodHeatmap(entries as any)).not.toThrow()
+    const result = buildHabitMoodHeatmap(entries as any)
+    expect(result[0].habit).toBe('run')
+    expect(result[0].counts[4]).toBe(1)
+  })
+
+  it('selects at most top 10 habits by frequency', () => {
+    const habits = Array.from({ length: 15 }, (_, i) => `habit_${i}`)
+    // habit_0 appears 15 times, habit_1 14 times, ... habit_14 1 time
+    const entries = habits.flatMap((h, i) =>
+      Array.from({ length: 15 - i }, () => makeEntry(3, [h])),
+    )
+    const result = buildHabitMoodHeatmap(entries as any)
+    expect(result).toHaveLength(10)
+    expect(result[0].habit).toBe('habit_0')
+    expect(result[9].habit).toBe('habit_9')
+  })
+
+  it('counts multiple habits across mood scores', () => {
+    const entries = [
+      makeEntry(1, ['sleep', 'exercise']),
+      makeEntry(5, ['sleep']),
+      makeEntry(5, ['exercise']),
+    ]
+    const result = buildHabitMoodHeatmap(entries as any)
+    const sleep = result.find((r) => r.habit === 'sleep')!
+    const exercise = result.find((r) => r.habit === 'exercise')!
+    expect(sleep.counts[1]).toBe(1)
+    expect(sleep.counts[5]).toBe(1)
+    expect(exercise.counts[1]).toBe(1)
+    expect(exercise.counts[5]).toBe(1)
   })
 })

--- a/frontend/src/features/analytics/analytics-page.tsx
+++ b/frontend/src/features/analytics/analytics-page.tsx
@@ -7,6 +7,7 @@ import {
 } from 'recharts'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../lib/auth-context'
+import { HabitMoodHeatmap } from './components/HabitMoodHeatmap'
 
 type LogEntry = {
   id: string
@@ -399,6 +400,17 @@ export function AnalyticsPage() {
               </div>
             ))}
           </div>
+        </section>
+      )}
+
+      {/* Habit × Mood heatmap (requires ≥14 entries) */}
+      {entries.length >= 14 && (
+        <section className="card">
+          <h2 style={{ marginTop: 0 }}>Habit × Mood Heatmap</h2>
+          <p className="muted" style={{ marginTop: 0, marginBottom: '1rem', fontSize: '0.85rem' }}>
+            How often each habit was logged on days with a given mood score.
+          </p>
+          <HabitMoodHeatmap entries={entries} />
         </section>
       )}
 

--- a/frontend/src/features/analytics/components/HabitMoodHeatmap.tsx
+++ b/frontend/src/features/analytics/components/HabitMoodHeatmap.tsx
@@ -1,0 +1,169 @@
+import { useRef, useState } from 'react'
+import { toPng } from 'html-to-image'
+import { buildHabitMoodHeatmap } from '../analytics-helpers'
+import type { AnalyticsLogEntry } from '../analytics-helpers'
+
+const MOOD_LABELS = ['😢 1', '😕 2', '😐 3', '🙂 4', '😄 5']
+const MOOD_SCORES = [1, 2, 3, 4, 5]
+const BRAND_RGB = '20, 99, 255'
+
+type Props = {
+  entries: Pick<AnalyticsLogEntry, 'mood' | 'habits'>[]
+}
+
+export function HabitMoodHeatmap({ entries }: Props) {
+  const gridRef = useRef<HTMLDivElement>(null)
+  const [copying, setCopying] = useState(false)
+
+  const rows = buildHabitMoodHeatmap(entries as AnalyticsLogEntry[])
+
+  if (rows.length === 0) return null
+
+  const maxCount = Math.max(...rows.flatMap((r) => Object.values(r.counts)))
+
+  function cellBg(count: number): string {
+    if (maxCount === 0 || count === 0) return 'var(--surface-soft)'
+    const intensity = count / maxCount
+    return `rgba(${BRAND_RGB}, ${Math.max(0.12, intensity)})`
+  }
+
+  async function handleCopy() {
+    if (!gridRef.current) return
+    setCopying(true)
+    try {
+      const dataUrl = await toPng(gridRef.current, { backgroundColor: 'var(--surface)' })
+      const a = document.createElement('a')
+      a.href = dataUrl
+      a.download = 'habit-mood-heatmap.png'
+      a.click()
+    } finally {
+      setCopying(false)
+    }
+  }
+
+  const colWidth = '3rem'
+  const labelWidth = '9rem'
+
+  return (
+    <div>
+      <div ref={gridRef} style={{ overflowX: 'auto', paddingBottom: '0.25rem' }}>
+        {/* Header row */}
+        <div style={{ display: 'flex', gap: '4px', marginBottom: '4px', paddingLeft: labelWidth }}>
+          {MOOD_LABELS.map((label) => (
+            <div
+              key={label}
+              style={{
+                width: colWidth,
+                flexShrink: 0,
+                textAlign: 'center',
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: 'var(--muted)',
+              }}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Data rows */}
+        {rows.map((row) => (
+          <div
+            key={row.habit}
+            style={{ display: 'flex', gap: '4px', marginBottom: '4px', alignItems: 'center' }}
+          >
+            <div
+              style={{
+                width: labelWidth,
+                flexShrink: 0,
+                fontSize: '0.8rem',
+                color: 'var(--text)',
+                fontWeight: 500,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                paddingRight: '0.5rem',
+              }}
+              title={row.habit}
+            >
+              {row.habit}
+            </div>
+            {MOOD_SCORES.map((score) => {
+              const count = row.counts[score] ?? 0
+              return (
+                <div
+                  key={score}
+                  title={`${row.habit} logged on ${count} day${count !== 1 ? 's' : ''} when mood was ${score}`}
+                  style={{
+                    width: colWidth,
+                    height: '2.2rem',
+                    flexShrink: 0,
+                    borderRadius: '6px',
+                    background: cellBg(count),
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: '0.75rem',
+                    fontWeight: 600,
+                    color: count > 0 && count / maxCount > 0.5 ? '#fff' : 'var(--text)',
+                    border: '1px solid var(--line)',
+                    transition: 'opacity 0.15s',
+                    cursor: 'default',
+                  }}
+                >
+                  {count > 0 ? count : ''}
+                </div>
+              )
+            })}
+          </div>
+        ))}
+      </div>
+
+      <div style={{ marginTop: '0.75rem', display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontSize: '0.78rem', color: 'var(--muted)' }}>
+          <span
+            style={{
+              display: 'inline-block',
+              width: '1rem',
+              height: '1rem',
+              borderRadius: '3px',
+              background: 'var(--surface-soft)',
+              border: '1px solid var(--line)',
+            }}
+          />
+          0
+          <span
+            style={{
+              display: 'inline-block',
+              width: '1rem',
+              height: '1rem',
+              borderRadius: '3px',
+              background: `rgba(${BRAND_RGB}, 0.5)`,
+            }}
+          />
+          mid
+          <span
+            style={{
+              display: 'inline-block',
+              width: '1rem',
+              height: '1rem',
+              borderRadius: '3px',
+              background: `rgba(${BRAND_RGB}, 1)`,
+            }}
+          />
+          max
+        </div>
+
+        <button
+          type="button"
+          className="chip"
+          style={{ marginLeft: 'auto', fontSize: '0.8rem' }}
+          onClick={() => void handleCopy()}
+          disabled={copying}
+        >
+          {copying ? 'Saving…' : 'Copy as image'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -16,6 +16,9 @@ export function LoginPage() {
   })
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [rememberMe, setRememberMe] = useState(
+    () => localStorage.getItem('echo-remember-me') !== 'false',
+  )
 
   const validateForm = (): string | null => {
     if (!credentials.email) return 'Email is required'
@@ -96,6 +99,26 @@ export function LoginPage() {
               {error}
             </div>
           )}
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              id="remember-me"
+              type="checkbox"
+              checked={rememberMe}
+              onChange={(e) => {
+                const val = e.target.checked
+                setRememberMe(val)
+                localStorage.setItem('echo-remember-me', String(val))
+              }}
+              style={{ accentColor: 'var(--brand)', width: '1rem', height: '1rem', cursor: 'pointer' }}
+            />
+            <label
+              htmlFor="remember-me"
+              style={{ fontSize: '0.875rem', color: 'var(--muted)', cursor: 'pointer', userSelect: 'none' }}
+            >
+              Keep me signed in
+            </label>
+          </div>
 
           <Button
             type="submit"

--- a/frontend/src/features/settings/settings-page.tsx
+++ b/frontend/src/features/settings/settings-page.tsx
@@ -17,6 +17,7 @@ import { useTheme } from '../../lib/use-theme'
 import { useToast } from '../../lib/use-toast'
 import { supabase } from '../../lib/supabase'
 import { NotificationPrefs } from '../notifications/notification-prefs'
+import { jsPDF } from 'jspdf'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -615,6 +616,231 @@ export function SettingsPage() {
     }
   }
 
+  const handleExportPDF = async () => {
+    setExportError(null)
+    setExportLoading(true)
+    setExportProgress('Building your PDF… fetching entries')
+
+    try {
+      const { data: entries, error: entriesErr } = await supabase
+        .from('log_entries')
+        .select('date, mood, habits, notes')
+        .eq('user_id', user.id)
+        .order('date', { ascending: false })
+        .limit(300)
+      if (entriesErr) throw entriesErr
+
+      setExportProgress('Building your PDF… fetching insights')
+      const { data: insights, error: insightsErr } = await supabase
+        .from('insights')
+        .select('prediction, suggestions, created_at')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false })
+        .limit(3)
+      if (insightsErr) throw insightsErr
+
+      setExportProgress('Building your PDF… finishing')
+
+      const MOOD_EMOJI: Record<number, string> = { 1: '😢', 2: '😕', 3: '😐', 4: '🙂', 5: '😄' }
+      const safeEntries = entries ?? []
+      const safeInsights = insights ?? []
+
+      const totalEntries = safeEntries.length
+      const avgMood =
+        totalEntries > 0
+          ? (
+              safeEntries.filter((e) => e.mood != null).reduce((s, e) => s + (e.mood ?? 0), 0) /
+              safeEntries.filter((e) => e.mood != null).length
+            ).toFixed(2)
+          : 'N/A'
+      const dateRange =
+        totalEntries > 0
+          ? `${safeEntries[safeEntries.length - 1].date} → ${safeEntries[0].date}`
+          : 'No entries'
+
+      const doc = new jsPDF({ unit: 'pt', format: 'a4' })
+      const W = doc.internal.pageSize.getWidth()
+      const H = doc.internal.pageSize.getHeight()
+      const margin = 48
+      const contentW = W - margin * 2
+      const BRAND = [20, 99, 255] as const
+      const FOOTER_TEXT = 'Generated locally by EchoMirror — your data never left your device'
+
+      const addFooter = () => {
+        doc.setFontSize(8)
+        doc.setTextColor(120, 130, 145)
+        doc.text(FOOTER_TEXT, W / 2, H - 20, { align: 'center' })
+      }
+
+      // ── Cover page ──────────────────────────────────────────
+      doc.setFillColor(...BRAND)
+      doc.rect(0, 0, W, 6, 'F')
+
+      doc.setFontSize(28)
+      doc.setTextColor(...BRAND)
+      doc.setFont('helvetica', 'bold')
+      doc.text('EchoMirror', margin, 80)
+
+      doc.setFontSize(16)
+      doc.setTextColor(30, 40, 55)
+      doc.setFont('helvetica', 'normal')
+      doc.text('Mood Journal Export', margin, 108)
+
+      doc.setDrawColor(210, 220, 235)
+      doc.line(margin, 122, W - margin, 122)
+
+      const coverFields = [
+        ['Email', user.email ?? ''],
+        ['Date range', dateRange],
+        ['Total entries', String(totalEntries)],
+        ['Average mood', avgMood],
+      ]
+      let y = 152
+      for (const [label, value] of coverFields) {
+        doc.setFontSize(10)
+        doc.setTextColor(90, 100, 115)
+        doc.setFont('helvetica', 'bold')
+        doc.text(label, margin, y)
+        doc.setFont('helvetica', 'normal')
+        doc.setTextColor(30, 40, 55)
+        doc.text(value, margin + 120, y)
+        y += 24
+      }
+
+      addFooter()
+
+      // ── Mood distribution page ──────────────────────────────
+      doc.addPage()
+      doc.setFillColor(...BRAND)
+      doc.rect(0, 0, W, 6, 'F')
+
+      doc.setFontSize(16)
+      doc.setTextColor(...BRAND)
+      doc.setFont('helvetica', 'bold')
+      doc.text('Mood Distribution', margin, 50)
+
+      const moodCounts: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+      for (const e of safeEntries) {
+        if (e.mood != null) moodCounts[e.mood] = (moodCounts[e.mood] ?? 0) + 1
+      }
+      const maxCount = Math.max(...Object.values(moodCounts), 1)
+      const barMaxW = contentW - 60
+      y = 80
+      const emojiMap: Record<number, string> = { 1: '1 Terrible', 2: '2 Bad', 3: '3 Okay', 4: '4 Good', 5: '5 Great' }
+      for (let score = 1; score <= 5; score++) {
+        const count = moodCounts[score]
+        const barW = (count / maxCount) * barMaxW
+        doc.setFontSize(10)
+        doc.setFont('helvetica', 'normal')
+        doc.setTextColor(30, 40, 55)
+        doc.text(emojiMap[score], margin, y + 10)
+        doc.setFillColor(...BRAND)
+        if (barW > 0) doc.rect(margin + 68, y - 2, barW, 14, 'F')
+        doc.setTextColor(80, 90, 105)
+        doc.text(String(count), margin + 68 + barW + 6, y + 10)
+        y += 28
+      }
+
+      addFooter()
+
+      // ── Entries pages (10 per page) ─────────────────────────
+      const PAGE_SIZE = 10
+      const pages = Math.ceil(safeEntries.length / PAGE_SIZE)
+      for (let p = 0; p < pages; p++) {
+        doc.addPage()
+        doc.setFillColor(...BRAND)
+        doc.rect(0, 0, W, 6, 'F')
+
+        doc.setFontSize(14)
+        doc.setTextColor(...BRAND)
+        doc.setFont('helvetica', 'bold')
+        doc.text(`Mood Entries (${p + 1}/${pages})`, margin, 46)
+
+        y = 72
+        const slice = safeEntries.slice(p * PAGE_SIZE, (p + 1) * PAGE_SIZE)
+        for (const entry of slice) {
+          if (y > H - 80) break
+          const emoji = entry.mood != null ? (MOOD_EMOJI[entry.mood] ?? String(entry.mood)) : '—'
+          doc.setFontSize(10)
+          doc.setFont('helvetica', 'bold')
+          doc.setTextColor(30, 40, 55)
+          doc.text(`${entry.date}  ${emoji}`, margin, y)
+
+          if (Array.isArray(entry.habits) && entry.habits.length > 0) {
+            doc.setFont('helvetica', 'normal')
+            doc.setFontSize(9)
+            doc.setTextColor(70, 90, 115)
+            const habitsLine = entry.habits.join(', ')
+            const wrapped = doc.splitTextToSize(habitsLine, contentW)
+            doc.text(wrapped, margin, y + 13)
+            y += 13 * wrapped.length
+          }
+
+          if (entry.notes) {
+            doc.setFont('helvetica', 'italic')
+            doc.setFontSize(9)
+            doc.setTextColor(90, 100, 115)
+            const noteLines = doc.splitTextToSize(entry.notes, contentW)
+            doc.text(noteLines, margin, y + 13)
+            y += 13 * noteLines.length
+          }
+
+          doc.setDrawColor(220, 228, 240)
+          doc.line(margin, y + 16, W - margin, y + 16)
+          y += 28
+        }
+
+        addFooter()
+      }
+
+      // ── AI Insights page ────────────────────────────────────
+      if (safeInsights.length > 0) {
+        doc.addPage()
+        doc.setFillColor(...BRAND)
+        doc.rect(0, 0, W, 6, 'F')
+
+        doc.setFontSize(14)
+        doc.setTextColor(...BRAND)
+        doc.setFont('helvetica', 'bold')
+        doc.text('AI Insights', margin, 46)
+
+        y = 72
+        for (const insight of safeInsights) {
+          if (y > H - 80) break
+          doc.setFontSize(10)
+          doc.setFont('helvetica', 'bold')
+          doc.setTextColor(30, 40, 55)
+          const predLines = doc.splitTextToSize(insight.prediction ?? '', contentW)
+          doc.text(predLines, margin, y)
+          y += 14 * predLines.length + 4
+
+          if (Array.isArray(insight.suggestions)) {
+            doc.setFont('helvetica', 'normal')
+            doc.setFontSize(9)
+            doc.setTextColor(70, 90, 115)
+            for (const s of insight.suggestions.slice(0, 3)) {
+              const sLines = doc.splitTextToSize(`• ${s}`, contentW - 12)
+              doc.text(sLines, margin + 8, y)
+              y += 13 * sLines.length
+            }
+          }
+
+          y += 16
+        }
+
+        addFooter()
+      }
+
+      doc.save('echomirror-journal.pdf')
+      showToast('PDF downloaded', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'PDF export failed', 'error')
+    } finally {
+      setExportLoading(false)
+      setExportProgress(null)
+    }
+  }
+
   const handleSaveProfile = async () => {
     setProfileSaving(true)
     try {
@@ -854,9 +1080,19 @@ export function SettingsPage() {
               </button>
             ))}
           </div>
-          <button type="button" onClick={() => void handleExport()} disabled={exportLoading}>
-            {exportLoading ? exportProgress ?? 'Exporting…' : 'Export my data'}
-          </button>
+          <div style={{ display: 'flex', gap: '0.6rem', flexWrap: 'wrap' }}>
+            <button type="button" onClick={() => void handleExport()} disabled={exportLoading}>
+              {exportLoading ? exportProgress ?? 'Exporting…' : 'Export my data'}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleExportPDF()}
+              disabled={exportLoading}
+              style={{ background: 'transparent', color: 'var(--brand)', border: '1.5px solid var(--brand)' }}
+            >
+              {exportLoading ? exportProgress ?? 'Building PDF…' : 'Export as PDF'}
+            </button>
+          </div>
           {exportError && <p className="error-text">{exportError}</p>}
         </div>
       </article>

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -9,4 +9,15 @@ if (!supabaseUrl || !supabaseAnonKey) {
   )
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+// Use sessionStorage when the user has explicitly opted out of persistent sessions.
+// The preference is stored in localStorage so it survives tab close (but not browser restart).
+const rememberMe =
+  typeof localStorage !== 'undefined'
+    ? localStorage.getItem('echo-remember-me') !== 'false'
+    : true
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    storage: rememberMe ? localStorage : sessionStorage,
+  },
+})

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -20,6 +20,8 @@ import '../../features/ai/view/screens/breathing_exercise_screen.dart';
 import '../../features/ai/view/screens/music_recommendations_screen.dart';
 import '../../features/global_mirror/view/screens/gift_screen.dart';
 import '../../features/global_mirror/view/screens/wallet_screen.dart';
+import '../../features/profile/view/screens/profile_screen.dart';
+import '../../features/habits/view/screens/habits_screen.dart';
 
 /// Refresh notifier for GoRouter
 class GoRouterRefreshNotifier extends ChangeNotifier {
@@ -186,6 +188,16 @@ final routerProvider = Provider<GoRouter>((ref) {
         name: 'gift',
         builder: (context, state) =>
             GiftScreen(recipientUserId: state.pathParameters['userId']!),
+      ),
+      GoRoute(
+        path: '/profile',
+        name: 'profile',
+        builder: (context, state) => const ProfileScreen(),
+      ),
+      GoRoute(
+        path: '/habits',
+        name: 'habits',
+        builder: (context, state) => const HabitsScreen(),
       ),
     ],
   );

--- a/lib/features/auth/view/screens/login_screen.dart
+++ b/lib/features/auth/view/screens/login_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../../../core/constants/app_strings.dart';
 import '../../../../core/utils/error_handler.dart';
 import '../../../../core/themes/app_theme.dart';
@@ -22,6 +23,19 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   bool _obscurePassword = true;
+  bool _keepMeSignedIn = true;
+
+  @override
+  void initState() {
+    super.initState();
+    SharedPreferences.getInstance().then((prefs) {
+      if (mounted) {
+        setState(() {
+          _keepMeSignedIn = prefs.getBool('echo_remember_me') ?? true;
+        });
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -33,6 +47,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   Future<void> _handleLogin() async {
     if (_formKey.currentState!.validate()) {
       debugPrint('[LoginScreen] Attempt login -> ${_emailController.text}');
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool('echo_remember_me', _keepMeSignedIn);
       final authNotifier = ref.read(authProvider.notifier);
       final success = await authNotifier.signIn(
         _emailController.text.trim(),
@@ -136,7 +152,23 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       return null;
                     },
                   ),
-                  const SizedBox(height: 32),
+                  const SizedBox(height: 8),
+                  // Keep me signed in
+                  SwitchListTile(
+                    value: _keepMeSignedIn,
+                    onChanged: (val) async {
+                      setState(() => _keepMeSignedIn = val);
+                      final prefs = await SharedPreferences.getInstance();
+                      await prefs.setBool('echo_remember_me', val);
+                    },
+                    title: Text(
+                      'Keep me signed in',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    activeColor: AppTheme.primaryColor,
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                  const SizedBox(height: 16),
                   // Login button
                   CustomButton(
                     onPressed: authState.isLoading ? null : _handleLogin,

--- a/lib/features/auth/viewmodel/providers/auth_provider.dart
+++ b/lib/features/auth/viewmodel/providers/auth_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../data/models/user_model.dart';
 import '../../data/repositories/auth_repository.dart';
 
@@ -42,6 +43,20 @@ class AuthNotifier extends StateNotifier<AuthState> {
     _isCheckingAuth = true;
     state = state.copyWith(isLoading: true);
     try {
+      // If the user opted out of persistent sessions, clear session on cold start.
+      final prefs = await SharedPreferences.getInstance();
+      final keepMeSignedIn = prefs.getBool('echo_remember_me') ?? true;
+      if (!keepMeSignedIn) {
+        debugPrint('[AuthNotifier] echo_remember_me=false — clearing session on cold start');
+        try {
+          await _repository.signOut();
+        } catch (_) {
+          // No session to clear — safe to ignore
+        }
+        state = const AuthState();
+        return;
+      }
+
       final isAuth = await _repository.isAuthenticated();
       debugPrint('[AuthNotifier] Auth check result: $isAuth');
 

--- a/lib/features/habits/view/screens/habits_screen.dart
+++ b/lib/features/habits/view/screens/habits_screen.dart
@@ -1,0 +1,310 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../../../../core/themes/app_theme.dart';
+import '../../../../core/utils/error_handler.dart';
+
+class HabitsScreen extends ConsumerStatefulWidget {
+  const HabitsScreen({super.key});
+
+  @override
+  ConsumerState<HabitsScreen> createState() => _HabitsScreenState();
+}
+
+class _HabitsScreenState extends ConsumerState<HabitsScreen> {
+  final _client = Supabase.instance.client;
+
+  bool _loading = true;
+
+  // All unique habits fetched from log_entries, with usage counts
+  Map<String, int> _usageCounts = {};
+
+  // Ordered list of habit names (after applying saved order)
+  List<String> _habits = [];
+
+  // Habits hidden by the user (soft-deleted)
+  Set<String> _hidden = {};
+
+  // Display aliases: habit -> renamed label
+  Map<String, String> _aliases = {};
+
+  // Custom habits added by the user (not from log entries)
+  List<String> _customHabits = [];
+
+  static const _kOrder = 'habit_display_order';
+  static const _kHidden = 'hidden_habits';
+  static const _kAliases = 'habit_aliases';
+  static const _kCustom = 'custom_habits';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadHabits();
+  }
+
+  Future<void> _loadHabits() async {
+    setState(() => _loading = true);
+    try {
+      final user = _client.auth.currentUser;
+      if (user == null) return;
+
+      // Fetch all habits from log_entries
+      final rows = await _client
+          .from('log_entries')
+          .select('habits')
+          .eq('user_id', user.id);
+
+      final Map<String, int> counts = {};
+      for (final row in (rows as List)) {
+        final habits = row['habits'];
+        if (habits is List) {
+          for (final h in habits) {
+            if (h is String && h.isNotEmpty) {
+              counts[h] = (counts[h] ?? 0) + 1;
+            }
+          }
+        }
+      }
+
+      final prefs = await SharedPreferences.getInstance();
+      final hiddenList = prefs.getStringList(_kHidden) ?? [];
+      _hidden = hiddenList.toSet();
+
+      final aliasesStr = prefs.getString(_kAliases);
+      _aliases = aliasesStr != null
+          ? Map<String, String>.from(jsonDecode(aliasesStr) as Map)
+          : {};
+
+      final customList = prefs.getStringList(_kCustom) ?? [];
+      _customHabits = customList;
+      for (final c in customList) {
+        counts.putIfAbsent(c, () => 0);
+      }
+
+      _usageCounts = counts;
+
+      // Apply saved order
+      final savedOrder = prefs.getStringList(_kOrder);
+      final allHabits = counts.keys.where((h) => !_hidden.contains(h)).toList();
+      if (savedOrder != null && savedOrder.isNotEmpty) {
+        final savedSet = savedOrder.toSet();
+        final ordered = savedOrder.where((h) => allHabits.contains(h)).toList();
+        final remaining = allHabits.where((h) => !savedSet.contains(h)).toList()
+          ..sort((a, b) => (counts[b] ?? 0).compareTo(counts[a] ?? 0));
+        _habits = [...ordered, ...remaining];
+      } else {
+        _habits = allHabits
+          ..sort((a, b) => (counts[b] ?? 0).compareTo(counts[a] ?? 0));
+      }
+    } catch (e) {
+      debugPrint('[HabitsScreen] load error: $e');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _saveOrder() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_kOrder, _habits);
+  }
+
+  Future<void> _hideHabit(String habit) async {
+    final prefs = await SharedPreferences.getInstance();
+    _hidden.add(habit);
+    await prefs.setStringList(_kHidden, _hidden.toList());
+    setState(() => _habits.remove(habit));
+  }
+
+  Future<void> _undoHide(String habit) async {
+    final prefs = await SharedPreferences.getInstance();
+    _hidden.remove(habit);
+    await prefs.setStringList(_kHidden, _hidden.toList());
+    setState(() => _habits.insert(0, habit));
+  }
+
+  Future<void> _renameHabit(String original) async {
+    final controller = TextEditingController(text: _aliases[original] ?? original);
+    final result = await showDialog<String>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Rename habit'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(hintText: 'New name'),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (result != null && result.isNotEmpty) {
+      final prefs = await SharedPreferences.getInstance();
+      if (result == original) {
+        _aliases.remove(original);
+      } else {
+        _aliases[original] = result;
+      }
+      await prefs.setString(_kAliases, jsonEncode(_aliases));
+      setState(() {});
+    }
+  }
+
+  Future<void> _addCustomHabit() async {
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Add habit'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(hintText: 'Habit name'),
+          textCapitalization: TextCapitalization.sentences,
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+    if (result != null && result.isNotEmpty && !_habits.contains(result)) {
+      final prefs = await SharedPreferences.getInstance();
+      _customHabits.add(result);
+      await prefs.setStringList(_kCustom, _customHabits);
+      _usageCounts[result] = 0;
+      setState(() => _habits.insert(0, result));
+      await _saveOrder();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Manage Habits', style: theme.textTheme.headlineSmall),
+        elevation: 0,
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addCustomHabit,
+        backgroundColor: AppTheme.primaryColor,
+        child: Icon(FontAwesomeIcons.plus.data, color: Colors.white, size: 18),
+        tooltip: 'Add habit',
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _habits.isEmpty
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(FontAwesomeIcons.listCheck.data, size: 48, color: theme.colorScheme.onSurface.withValues(alpha: 0.3)),
+                      const SizedBox(height: 16),
+                      Text('No habits yet', style: theme.textTheme.titleMedium?.copyWith(color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
+                      const SizedBox(height: 8),
+                      Text('Log some entries to see your habits here', style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurface.withValues(alpha: 0.4))),
+                    ],
+                  ),
+                )
+              : ReorderableListView.builder(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 100),
+                  itemCount: _habits.length,
+                  onReorder: (oldIndex, newIndex) {
+                    setState(() {
+                      if (newIndex > oldIndex) newIndex--;
+                      final item = _habits.removeAt(oldIndex);
+                      _habits.insert(newIndex, item);
+                    });
+                    _saveOrder();
+                  },
+                  itemBuilder: (context, index) {
+                    final habit = _habits[index];
+                    final displayName = _aliases[habit] ?? habit;
+                    final count = _usageCounts[habit] ?? 0;
+
+                    return Dismissible(
+                      key: ValueKey(habit),
+                      direction: DismissDirection.endToStart,
+                      background: Container(
+                        alignment: Alignment.centerRight,
+                        padding: const EdgeInsets.only(right: 20),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                        child: Icon(FontAwesomeIcons.trash.data, color: Colors.red, size: 18),
+                      ),
+                      confirmDismiss: (_) async => true,
+                      onDismissed: (_) {
+                        _hideHabit(habit);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text('"$displayName" removed'),
+                            action: SnackBarAction(
+                              label: 'Undo',
+                              onPressed: () => _undoHide(habit),
+                            ),
+                          ),
+                        );
+                      },
+                      child: Card(
+                        key: ValueKey('card_$habit'),
+                        elevation: 0,
+                        margin: const EdgeInsets.symmetric(vertical: 4),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(14),
+                          side: BorderSide(
+                            color: theme.colorScheme.outline.withValues(alpha: 0.12),
+                          ),
+                        ),
+                        child: ListTile(
+                          contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                          leading: Container(
+                            padding: const EdgeInsets.all(8),
+                            decoration: BoxDecoration(
+                              color: AppTheme.primaryColor.withValues(alpha: 0.1),
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Icon(FontAwesomeIcons.star.data, size: 14, color: AppTheme.primaryColor),
+                          ),
+                          title: Text(displayName, style: theme.textTheme.titleSmall),
+                          subtitle: Text(
+                            'Used $count time${count != 1 ? 's' : ''}',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                            ),
+                          ),
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                icon: Icon(FontAwesomeIcons.penToSquare.data, size: 14, color: theme.colorScheme.onSurface.withValues(alpha: 0.4)),
+                                onPressed: () => _renameHabit(habit),
+                                tooltip: 'Rename',
+                              ),
+                              ReorderableDragStartListener(
+                                index: index,
+                                child: Icon(FontAwesomeIcons.gripVertical.data, size: 16, color: theme.colorScheme.onSurface.withValues(alpha: 0.3)),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/features/profile/view/screens/profile_screen.dart
+++ b/lib/features/profile/view/screens/profile_screen.dart
@@ -1,0 +1,332 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../../../../core/themes/app_theme.dart';
+import '../../../../core/utils/error_handler.dart';
+import '../../../../core/widgets/shimmer_loading.dart';
+
+class ProfileScreen extends ConsumerStatefulWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  ConsumerState<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends ConsumerState<ProfileScreen> {
+  final _client = Supabase.instance.client;
+  final _nameController = TextEditingController();
+
+  bool _loading = true;
+  bool _editing = false;
+  bool _saving = false;
+  bool _uploadingAvatar = false;
+
+  String? _email;
+  String? _avatarUrl;
+  String? _displayName;
+  String? _memberSince;
+  int _totalLogs = 0;
+  int _streak = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProfile();
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadProfile() async {
+    setState(() => _loading = true);
+    try {
+      final user = _client.auth.currentUser;
+      if (user == null) return;
+
+      _email = user.email;
+      _memberSince = user.createdAt.split('T').first;
+
+      // Fetch profile row
+      final profileRes = await _client
+          .from('profiles')
+          .select('display_name, avatar_url')
+          .eq('id', user.id)
+          .maybeSingle();
+
+      if (profileRes != null) {
+        _displayName = profileRes['display_name'] as String?;
+        _avatarUrl = profileRes['avatar_url'] as String?;
+      }
+
+      // Fetch log count
+      final countRes = await _client
+          .from('log_entries')
+          .select('date')
+          .eq('user_id', user.id)
+          .order('date', ascending: false)
+          .limit(365);
+
+      final dates =
+          (countRes as List).map((e) => e['date'] as String).toList();
+      _totalLogs = dates.length;
+      _streak = _calculateStreak(dates);
+
+      _nameController.text = _displayName ?? '';
+    } catch (e) {
+      debugPrint('[ProfileScreen] load error: $e');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  int _calculateStreak(List<String> dates) {
+    if (dates.isEmpty) return 0;
+    int streak = 0;
+    DateTime cursor = DateTime.now();
+    for (final d in dates) {
+      final day = DateTime.tryParse(d);
+      if (day == null) break;
+      final diff = DateTime(cursor.year, cursor.month, cursor.day)
+          .difference(DateTime(day.year, day.month, day.day))
+          .inDays;
+      if (diff == 0 || diff == 1) {
+        streak++;
+        cursor = day;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  Future<void> _saveProfile() async {
+    final user = _client.auth.currentUser;
+    if (user == null) return;
+    setState(() => _saving = true);
+    try {
+      final name = _nameController.text.trim();
+      await _client.auth.updateUser(UserAttributes(data: {'display_name': name}));
+      await _client.from('profiles').upsert({
+        'id': user.id,
+        'display_name': name.isEmpty ? null : name,
+      });
+      setState(() {
+        _displayName = name.isEmpty ? null : name;
+        _editing = false;
+      });
+      if (mounted) ErrorHandler.showSuccess(context, 'Profile updated');
+    } catch (e) {
+      if (mounted) ErrorHandler.showError(context, 'Failed to save profile');
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  Future<void> _pickAndUploadAvatar() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery, maxWidth: 512, maxHeight: 512);
+    if (picked == null) return;
+
+    final user = _client.auth.currentUser;
+    if (user == null) return;
+
+    setState(() => _uploadingAvatar = true);
+    try {
+      final bytes = await File(picked.path).readAsBytes();
+      final ext = picked.path.split('.').last.toLowerCase();
+      final path = '${user.id}/avatar.$ext';
+
+      await _client.storage
+          .from('avatars')
+          .uploadBinary(path, bytes, fileOptions: FileOptions(upsert: true, contentType: 'image/$ext'));
+
+      final url = _client.storage.from('avatars').getPublicUrl(path);
+      await _client.from('profiles').upsert({'id': user.id, 'avatar_url': url});
+      setState(() => _avatarUrl = '$url?t=${DateTime.now().millisecondsSinceEpoch}');
+      if (mounted) ErrorHandler.showSuccess(context, 'Avatar updated');
+    } catch (e) {
+      if (mounted) ErrorHandler.showError(context, 'Avatar upload failed');
+    } finally {
+      if (mounted) setState(() => _uploadingAvatar = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('My Profile', style: theme.textTheme.headlineSmall),
+        elevation: 0,
+        actions: [
+          if (!_editing && !_loading)
+            IconButton(
+              icon: Icon(FontAwesomeIcons.penToSquare.data, size: 18),
+              onPressed: () => setState(() => _editing = true),
+              tooltip: 'Edit profile',
+            ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(24),
+              children: [
+                // Avatar
+                Center(
+                  child: GestureDetector(
+                    onTap: _pickAndUploadAvatar,
+                    child: Stack(
+                      alignment: Alignment.bottomRight,
+                      children: [
+                        CircleAvatar(
+                          radius: 52,
+                          backgroundColor: AppTheme.primaryColor.withValues(alpha: 0.15),
+                          backgroundImage:
+                              _avatarUrl != null ? NetworkImage(_avatarUrl!) : null,
+                          child: _uploadingAvatar
+                              ? const CircularProgressIndicator()
+                              : (_avatarUrl == null
+                                  ? Icon(FontAwesomeIcons.userAstronaut.data,
+                                      size: 40, color: AppTheme.primaryColor)
+                                  : null),
+                        ),
+                        Container(
+                          padding: const EdgeInsets.all(6),
+                          decoration: BoxDecoration(
+                            color: AppTheme.primaryColor,
+                            shape: BoxShape.circle,
+                            border: Border.all(color: Colors.white, width: 2),
+                          ),
+                          child: Icon(FontAwesomeIcons.camera.data,
+                              size: 13, color: Colors.white),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+
+                // Display name
+                Card(
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                    side: BorderSide(
+                      color: theme.colorScheme.outline.withValues(alpha: 0.12),
+                    ),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('Display name', style: theme.textTheme.labelMedium?.copyWith(color: theme.colorScheme.onSurface.withValues(alpha: 0.6))),
+                        const SizedBox(height: 8),
+                        if (_editing)
+                          Row(
+                            children: [
+                              Expanded(
+                                child: TextField(
+                                  controller: _nameController,
+                                  decoration: const InputDecoration(
+                                    hintText: 'Enter your name',
+                                    border: OutlineInputBorder(),
+                                    isDense: true,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              TextButton(
+                                onPressed: _saving ? null : _saveProfile,
+                                child: _saving
+                                    ? ShimmerLoading(width: 16, height: 16)
+                                    : const Text('Save'),
+                              ),
+                              TextButton(
+                                onPressed: () {
+                                  _nameController.text = _displayName ?? '';
+                                  setState(() => _editing = false);
+                                },
+                                child: const Text('Cancel'),
+                              ),
+                            ],
+                          )
+                        else
+                          Text(
+                            _displayName?.isNotEmpty == true ? _displayName! : 'Not set',
+                            style: theme.textTheme.titleMedium,
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+
+                // Info cards
+                _infoCard(theme, [
+                  _infoRow(theme, FontAwesomeIcons.envelope, 'Email', _email ?? '—', Colors.blue),
+                  Divider(height: 1, color: theme.colorScheme.outline.withValues(alpha: 0.1)),
+                  _infoRow(theme, FontAwesomeIcons.calendarCheck, 'Member since', _memberSince ?? '—', Colors.green),
+                ]),
+                const SizedBox(height: 16),
+                _infoCard(theme, [
+                  _infoRow(theme, FontAwesomeIcons.bookOpen, 'Total logs', '$_totalLogs entries', AppTheme.primaryColor),
+                  Divider(height: 1, color: theme.colorScheme.outline.withValues(alpha: 0.1)),
+                  _infoRow(theme, FontAwesomeIcons.fire, 'Current streak', '$_streak day${_streak != 1 ? 's' : ''}', Colors.orange),
+                ]),
+              ],
+            ),
+    );
+  }
+
+  Widget _infoCard(ThemeData theme, List<Widget> children) {
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.12)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(4),
+        child: Column(children: children),
+      ),
+    );
+  }
+
+  Widget _infoRow(ThemeData theme, IconData icon, String label, String value, Color iconColor) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: iconColor.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(icon, size: 16, color: iconColor),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurface.withValues(alpha: 0.6))),
+                const SizedBox(height: 2),
+                Text(value, style: theme.textTheme.titleSmall),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/view/screens/settings_screen.dart
+++ b/lib/features/settings/view/screens/settings_screen.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:go_router/go_router.dart';
+import 'package:printing/printing.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../../../core/constants/app_strings.dart';
 import '../../../../core/themes/app_theme.dart';
 import '../../../../core/viewmodel/providers/theme_provider.dart';
@@ -52,6 +56,18 @@ class SettingsScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 12),
           _buildNotificationsCard(context, theme, ref),
+          const SizedBox(height: 24),
+
+          // Data Section
+          _buildSectionHeader(
+            context,
+            theme,
+            icon: FontAwesomeIcons.fileExport.data,
+            title: 'Data',
+            subtitle: 'Export your mood journal',
+          ),
+          const SizedBox(height: 12),
+          _buildDataCard(context, theme, authState),
           const SizedBox(height: 24),
 
           // Account Section
@@ -377,6 +393,42 @@ class SettingsScreen extends ConsumerWidget {
             _buildModernListTile(
               context,
               theme,
+              icon: FontAwesomeIcons.circleUser.data,
+              iconColor: AppTheme.primaryColor,
+              title: 'My Profile',
+              subtitle: 'Edit name and avatar',
+              trailing: Icon(
+                FontAwesomeIcons.chevronRight.data,
+                size: 14,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+              ),
+              onTap: () => context.push('/profile'),
+            ),
+            Divider(
+              height: 1,
+              color: theme.colorScheme.outline.withValues(alpha: 0.1),
+            ),
+            _buildModernListTile(
+              context,
+              theme,
+              icon: FontAwesomeIcons.listCheck.data,
+              iconColor: Colors.teal,
+              title: 'Manage Habits',
+              subtitle: 'Reorder, rename, or remove habits',
+              trailing: Icon(
+                FontAwesomeIcons.chevronRight.data,
+                size: 14,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+              ),
+              onTap: () => context.push('/habits'),
+            ),
+            Divider(
+              height: 1,
+              color: theme.colorScheme.outline.withValues(alpha: 0.1),
+            ),
+            _buildModernListTile(
+              context,
+              theme,
               icon: FontAwesomeIcons.key.data,
               iconColor: Colors.purple,
               title: 'Change Password',
@@ -408,6 +460,201 @@ class SettingsScreen extends ConsumerWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildDataCard(BuildContext context, ThemeData theme, dynamic authState) {
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: BorderSide(
+          color: theme.colorScheme.outline.withValues(alpha: 0.1),
+          width: 1,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(4),
+        child: _buildModernListTile(
+          context,
+          theme,
+          icon: FontAwesomeIcons.filePdf.data,
+          iconColor: Colors.red,
+          title: 'Export PDF',
+          subtitle: 'Download your mood journal as a PDF',
+          trailing: Icon(
+            FontAwesomeIcons.chevronRight.data,
+            size: 14,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+          ),
+          onTap: () => _generateAndSharePDF(context, authState),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _generateAndSharePDF(BuildContext context, dynamic authState) async {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(const SnackBar(content: Text('Building your PDF…')));
+
+    try {
+      final client = Supabase.instance.client;
+      final userId = (authState.user?.id as String?) ?? '';
+
+      final entriesRes = await client
+          .from('log_entries')
+          .select('date, mood, habits, notes')
+          .eq('user_id', userId)
+          .order('date', ascending: false)
+          .limit(300);
+
+      final insightsRes = await client
+          .from('insights')
+          .select('prediction, suggestions, created_at')
+          .eq('user_id', userId)
+          .order('created_at', ascending: false)
+          .limit(3);
+
+      final entries = (entriesRes as List).cast<Map<String, dynamic>>();
+      final insights = (insightsRes as List).cast<Map<String, dynamic>>();
+      final userEmail = authState.user?.email ?? '';
+
+      const moodEmoji = {1: '😢', 2: '😕', 3: '😐', 4: '🙂', 5: '😄'};
+
+      final totalEntries = entries.length;
+      final moodsWithValue = entries.where((e) => e['mood'] != null).toList();
+      final avgMood = moodsWithValue.isEmpty
+          ? 'N/A'
+          : (moodsWithValue.fold(0, (s, e) => s + (e['mood'] as int)) /
+                  moodsWithValue.length)
+              .toStringAsFixed(2);
+      final dateRange = totalEntries > 0
+          ? '${entries.last['date']} → ${entries.first['date']}'
+          : 'No entries';
+
+      const brand = PdfColor.fromInt(0xFF1463FF);
+      const footerText = 'Generated locally by EchoMirror — your data never left your device';
+
+      final doc = pw.Document();
+
+      // Cover page
+      doc.addPage(pw.Page(
+        pageFormat: PdfPageFormat.a4,
+        build: (pw.Context ctx) => pw.Column(
+          crossAxisAlignment: pw.CrossAxisAlignment.start,
+          children: [
+            pw.Container(height: 6, color: brand),
+            pw.SizedBox(height: 32),
+            pw.Text('EchoMirror', style: pw.TextStyle(fontSize: 28, fontWeight: pw.FontWeight.bold, color: brand)),
+            pw.SizedBox(height: 8),
+            pw.Text('Mood Journal Export', style: pw.TextStyle(fontSize: 16, color: PdfColors.blueGrey700)),
+            pw.Divider(color: PdfColors.blueGrey100),
+            pw.SizedBox(height: 16),
+            _pdfRow('Email', userEmail),
+            _pdfRow('Date range', dateRange),
+            _pdfRow('Total entries', '$totalEntries'),
+            _pdfRow('Average mood', avgMood),
+            pw.Spacer(),
+            pw.Text(footerText, style: pw.TextStyle(fontSize: 8, color: PdfColors.grey500)),
+          ],
+        ),
+      ));
+
+      // Entries pages (10 per page)
+      const pageSize = 10;
+      final pages = (totalEntries / pageSize).ceil();
+      for (int p = 0; p < pages; p++) {
+        final slice = entries.skip(p * pageSize).take(pageSize).toList();
+        doc.addPage(pw.Page(
+          pageFormat: PdfPageFormat.a4,
+          build: (pw.Context ctx) => pw.Column(
+            crossAxisAlignment: pw.CrossAxisAlignment.start,
+            children: [
+              pw.Container(height: 4, color: brand),
+              pw.SizedBox(height: 16),
+              pw.Text('Mood Entries (${p + 1}/$pages)',
+                  style: pw.TextStyle(fontSize: 14, fontWeight: pw.FontWeight.bold, color: brand)),
+              pw.SizedBox(height: 12),
+              ...slice.map((entry) {
+                final mood = entry['mood'] as int?;
+                final emoji = mood != null ? (moodEmoji[mood] ?? '$mood') : '—';
+                final habits = (entry['habits'] as List?)?.cast<String>().join(', ') ?? '';
+                final notes = entry['notes'] as String? ?? '';
+                return pw.Column(
+                  crossAxisAlignment: pw.CrossAxisAlignment.start,
+                  children: [
+                    pw.Text('${entry['date']}  $emoji',
+                        style: pw.TextStyle(fontWeight: pw.FontWeight.bold, fontSize: 10)),
+                    if (habits.isNotEmpty)
+                      pw.Text(habits,
+                          style: pw.TextStyle(fontSize: 9, color: PdfColors.blueGrey600)),
+                    if (notes.isNotEmpty)
+                      pw.Text(notes,
+                          style: pw.TextStyle(fontSize: 9, color: PdfColors.grey600, fontStyle: pw.FontStyle.italic)),
+                    pw.Divider(color: PdfColors.blueGrey50),
+                  ],
+                );
+              }),
+              pw.Spacer(),
+              pw.Text(footerText, style: pw.TextStyle(fontSize: 8, color: PdfColors.grey500)),
+            ],
+          ),
+        ));
+      }
+
+      // Insights page
+      if (insights.isNotEmpty) {
+        doc.addPage(pw.Page(
+          pageFormat: PdfPageFormat.a4,
+          build: (pw.Context ctx) => pw.Column(
+            crossAxisAlignment: pw.CrossAxisAlignment.start,
+            children: [
+              pw.Container(height: 4, color: brand),
+              pw.SizedBox(height: 16),
+              pw.Text('AI Insights',
+                  style: pw.TextStyle(fontSize: 14, fontWeight: pw.FontWeight.bold, color: brand)),
+              pw.SizedBox(height: 12),
+              ...insights.map((insight) {
+                final prediction = insight['prediction'] as String? ?? '';
+                final suggestions = (insight['suggestions'] as List?)?.cast<String>() ?? [];
+                return pw.Column(
+                  crossAxisAlignment: pw.CrossAxisAlignment.start,
+                  children: [
+                    pw.Text(prediction,
+                        style: pw.TextStyle(fontWeight: pw.FontWeight.bold, fontSize: 10)),
+                    ...suggestions.take(3).map((s) =>
+                        pw.Text('• $s', style: pw.TextStyle(fontSize: 9, color: PdfColors.grey700))),
+                    pw.SizedBox(height: 12),
+                  ],
+                );
+              }),
+              pw.Spacer(),
+              pw.Text(footerText, style: pw.TextStyle(fontSize: 8, color: PdfColors.grey500)),
+            ],
+          ),
+        ));
+      }
+
+      final bytes = await doc.save();
+      await Printing.sharePdf(bytes: bytes, filename: 'echomirror-journal.pdf');
+    } catch (e) {
+      debugPrint('[SettingsScreen] PDF export error: $e');
+      messenger.showSnackBar(SnackBar(content: Text('PDF export failed: ${e.toString()}')));
+    }
+  }
+
+  pw.Widget _pdfRow(String label, String value) {
+    return pw.Padding(
+      padding: const pw.EdgeInsets.symmetric(vertical: 4),
+      child: pw.Row(
+        children: [
+          pw.SizedBox(
+            width: 100,
+            child: pw.Text(label, style: pw.TextStyle(fontWeight: pw.FontWeight.bold, fontSize: 10, color: PdfColors.blueGrey700)),
+          ),
+          pw.Text(value, style: pw.TextStyle(fontSize: 10)),
+        ],
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,10 @@ dependencies:
   stellar_flutter_sdk: ^2.0.0
   qr_flutter: ^4.1.0
 
+  # PDF Export
+  pdf: ^3.11.1
+  printing: ^5.13.2
+
   # Video Calls (Agora)
   agora_rtc_engine: ^6.3.0
   wakelock_plus: ^1.2.8


### PR DESCRIPTION
  Closes #499, closes #501, closes #494, closes #492

  ## Summary

  ### #499 — Habit × Mood Heatmap (web)
  - Added `buildHabitMoodHeatmap(entries)` to `analytics-helpers.ts` — returns top-10 habits × mood scores 1–5
  count grid
  - Created `HabitMoodHeatmap.tsx`: brand-blue intensity cells (`rgba(20,99,255, intensity)`), hover tooltips
  ("Exercise logged on 8 days when mood was 4"), "Copy as image" button via `html-to-image`
  - Rendered on the Analytics page below "Habits on High-Mood Days", gated to ≥ 14 entries; shows empty state
  for sparse data
  - Unit tests added for: empty input, single habit, multiple habits with top-10 trimming, null mood skip, null
  habits safety

  ### #501 — PDF Journal Export (web + Flutter)
  - **Web**: "Export as PDF" button in Settings → Data export; generates a `jspdf` PDF entirely client-side —
  cover page (email, date range, total entries, avg mood), mood distribution bar chart, paginated entries list
  (10/page, with emoji + habits + notes), AI insights section, privacy footer; progress indicator reuses
  existing `exportProgress` state
  - **Flutter**: "Export PDF" tile in Settings → Data section; fetches data locally from Supabase, builds a
  transmitted externally
  
  ### #494 — "Keep me signed in" on login (web + Flutter)
  - **Web**: `supabase.ts` client initialised with `storage: sessionStorage` when `echo-remember-me=false`
  (clears on tab close) or `localStorage` (default, persistent); "Keep me signed in" checkbox on `LoginPage.tsx`
  defaults to checked, saves preference to `localStorage`
  - **Flutter**: `SwitchListTile` on `LoginScreen` below password field, default true, persisted in
  `SharedPreferences`; on cold start, if `echo_remember_me=false`, session is cleared before auth check so user
  must log in again
  
  ### #492 — Flutter Profile + Habit Management Screens
  - **ProfileScreen** (`/profile`): circular avatar (tappable to upload via `image_picker`), inline display-name
  edit, read-only email, member-since date, total logs count, current streak; linked from Settings → Account
  - **HabitsScreen** (`/habits`): `ReorderableListView` of all habits with usage counts, `Dismissible`
  swipe-to-delete with undo SnackBar, inline rename dialog, FAB to add custom habits; order and aliases
  persisted in `SharedPreferences`; linked from Settings → Account
  - Both routes registered in `app_router.dart` 
  
  ## Test plan
  - [ ] Analytics page with ≥14 log entries shows the heatmap grid; cells scale from white (0) to brand blue
  (max); hover tooltip shows accurate count; "Copy as image" downloads a PNG
  - [ ] Analytics page with <14 entries: heatmap section absent
  - [ ] `npm test` in `frontend/` — all analytics helper tests pass (9 tests)
  - [ ] Settings → Export as PDF: progress shown, PDF downloads with cover page + entries + insights; DevTools
  Network shows no external calls during generation
  - [ ] Login page: uncheck "Keep me signed in" → log in → close tab → reopen → redirected to login. Check → log
  in → close + reopen browser → still logged in
  - [ ] Flutter: toggle off "Keep me signed in" → log in → force-quit → reopen → redirected to login
  - [ ] Flutter Settings → My Profile: avatar tappable, name editable, stats visible
  - [ ] Flutter Settings → Manage Habits: list populated, swipe removes with undo, reorder persists, rename
  works, FAB adds custom habit