### PR TITLE
feat(web): add mood check-in widget to dashboard for quick daily logging

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -12,6 +12,7 @@ import '../../features/dashboard/view/screens/mood_analytics_screen.dart';
 import '../../features/logging/view/screens/create_entry_screen.dart';
 import '../../features/logging/view/screens/entry_detail_screen.dart';
 import '../../features/logging/data/models/log_entry_model.dart';
+import '../../features/logging/data/models/quick_check_in_data.dart';
 import '../../features/onboarding/view/screens/onboarding_screen.dart';
 import '../../features/onboarding/viewmodel/providers/onboarding_provider.dart';
 import '../../features/dashboard/view/screens/main_navigation_screen.dart';
@@ -137,7 +138,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/logging/create',
         name: 'create-entry',
-        builder: (context, state) => const CreateEntryScreen(),
+        builder: (context, state) {
+          final prefill = state.extra as QuickCheckInData?;
+          return CreateEntryScreen(prefill: prefill);
+        },
       ),
       GoRoute(
         path: '/logging/detail/:id',

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -24,7 +24,7 @@ import '../../features/global_mirror/view/screens/wallet_screen.dart';
 import '../../features/profile/view/screens/profile_screen.dart';
 import '../../features/habits/view/screens/habits_screen.dart';
 
-/// Refresh notifier for GoRouter
+/// Refresh notifier for GoRouter.
 class GoRouterRefreshNotifier extends ChangeNotifier {
   GoRouterRefreshNotifier(this.ref) {
     ref.listen(
@@ -32,10 +32,11 @@ class GoRouterRefreshNotifier extends ChangeNotifier {
       (_, _) => notifyListeners(),
     );
   }
+
   final Ref ref;
 }
 
-/// App router configuration with GoRouter
+/// App router configuration with GoRouter.
 final routerProvider = Provider<GoRouter>((ref) {
   final notifier = GoRouterRefreshNotifier(ref);
   return GoRouter(
@@ -54,7 +55,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       final isVerifyEmail = state.matchedLocation == '/verify-email';
       final isAuthRoute = isLoggingIn || isSigningUp;
 
-      // /verify-email is always accessible — no redirect applied
+      // /verify-email is always accessible — no redirect applied.
       if (isVerifyEmail) return null;
 
       bool onboardingCompleted = false;
@@ -66,15 +67,9 @@ final routerProvider = Provider<GoRouter>((ref) {
         onboardingCompleted = false;
       }
 
-      if (!onboardingCompleted && !isOnboarding) {
-        return '/onboarding';
-      }
-      if (onboardingCompleted && isOnboarding) {
-        return '/login';
-      }
-      if (isAuthenticated && isAuthRoute) {
-        return '/dashboard';
-      }
+      if (!onboardingCompleted && !isOnboarding) return '/onboarding';
+      if (onboardingCompleted && isOnboarding) return '/login';
+      if (isAuthenticated && isAuthRoute) return '/dashboard';
       if (!isAuthenticated && !isAuthRoute && !isOnboarding) {
         return '/login';
       }
@@ -170,7 +165,8 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/notifications',
         name: 'notifications',
-        builder: (context, state) => const MoodCommentNotificationsScreen(),
+        builder: (context, state) =>
+            const MoodCommentNotificationsScreen(),
       ),
       GoRoute(
         path: '/breathing',
@@ -180,7 +176,8 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/music-recommendations',
         name: 'music-recommendations',
-        builder: (context, state) => const MusicRecommendationsScreen(),
+        builder: (context, state) =>
+            const MusicRecommendationsScreen(),
       ),
       GoRoute(
         path: '/wallet',
@@ -190,8 +187,9 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/gift/:userId',
         name: 'gift',
-        builder: (context, state) =>
-            GiftScreen(recipientUserId: state.pathParameters['userId']!),
+        builder: (context, state) => GiftScreen(
+          recipientUserId: state.pathParameters['userId']!,
+        ),
       ),
       GoRoute(
         path: '/profile',

--- a/lib/features/dashboard/view/screens/dashboard_screen.dart
+++ b/lib/features/dashboard/view/screens/dashboard_screen.dart
@@ -23,6 +23,9 @@ import '../widgets/mood_streak_card.dart';
 import '../widgets/mood_trend_chart.dart';
 import '../widgets/echo_balance_card.dart';
 import '../../viewmodel/providers/mood_chart_provider.dart';
+import '../../viewmodel/providers/has_logged_today_provider.dart';
+import '../widgets/quick_check_in_widget.dart';
+import '../widgets/daily_log_status_banner.dart';
 
 /// Dashboard screen showing insights and predictions
 class DashboardScreen extends ConsumerStatefulWidget {
@@ -64,6 +67,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
     final dashboardState = ref.watch(dashboardProvider);
     final authState = ref.watch(authProvider);
     final streakState = ref.watch(streakProvider);
+    final hasLoggedToday = ref.watch(hasLoggedTodayProvider);
     final theme = Theme.of(context);
 
     if (authState.isAuthenticated && authState.user != null) {
@@ -143,7 +147,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
           dashboardState.when(
             data: (insights) {
               if (insights.isEmpty) {
-                return _buildEmptyState(context, theme, ref);
+                return _buildEmptyState(context, theme, ref, hasLoggedToday);
               }
 
               _checkMilestones(insights);
@@ -182,6 +186,11 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      if (hasLoggedToday)
+                        const DailyLogStatusBanner()
+                      else
+                        const QuickCheckInWidget(),
+                      const SizedBox(height: 8),
                       DashboardStats(insights: insights),
                       const SizedBox(height: 8),
                       MoodStreakCard(streak: streakState.currentStreak),
@@ -329,6 +338,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
     BuildContext context,
     ThemeData theme,
     WidgetRef ref,
+    bool hasLoggedToday,
   ) {
     return Center(
       child: SingleChildScrollView(
@@ -337,6 +347,11 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
+              if (hasLoggedToday)
+                const DailyLogStatusBanner()
+              else
+                const QuickCheckInWidget(),
+              const SizedBox(height: 8),
               Container(
                 width: 120,
                 height: 120,

--- a/lib/features/dashboard/view/screens/dashboard_screen.dart
+++ b/lib/features/dashboard/view/screens/dashboard_screen.dart
@@ -27,7 +27,7 @@ import '../../viewmodel/providers/has_logged_today_provider.dart';
 import '../widgets/quick_check_in_widget.dart';
 import '../widgets/daily_log_status_banner.dart';
 
-/// Dashboard screen showing insights and predictions
+/// Dashboard screen showing insights and predictions.
 class DashboardScreen extends ConsumerStatefulWidget {
   const DashboardScreen({super.key});
 
@@ -55,7 +55,6 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
 
   void _checkMilestones(List<InsightModel> insights) {
     if (_hasCheckedMilestone) return;
-
     if (insights.length >= 7) {
       _hasCheckedMilestone = true;
       _confettiController.play();
@@ -97,15 +96,14 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
 
             if (logs.length >= 3) {
               final now = DateTime.now();
-              final recentLogs =
-                  logs
-                      .where(
-                        (log) => log.date.isAfter(
-                          now.subtract(const Duration(days: 14)),
-                        ),
-                      )
-                      .toList()
-                    ..sort((a, b) => b.date.compareTo(a.date));
+              final recentLogs = logs
+                  .where(
+                    (log) => log.date.isAfter(
+                      now.subtract(const Duration(days: 14)),
+                    ),
+                  )
+                  .toList()
+                ..sort((a, b) => b.date.compareTo(a.date));
 
               if (recentLogs.length >= 3) {
                 if (!mounted) return;
@@ -147,32 +145,40 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
           dashboardState.when(
             data: (insights) {
               if (insights.isEmpty) {
-                return _buildEmptyState(context, theme, ref, hasLoggedToday);
+                return _buildEmptyState(
+                  context,
+                  theme,
+                  ref,
+                  hasLoggedToday,
+                );
               }
 
               _checkMilestones(insights);
 
-              final predictions =
-                  insights
-                      .where((i) => i.type == InsightType.prediction)
-                      .toList()
-                    ..sort((a, b) => b.date.compareTo(a.date));
+              final predictions = insights
+                  .where((i) => i.type == InsightType.prediction)
+                  .toList()
+                ..sort((a, b) => b.date.compareTo(a.date));
 
-              final habits =
-                  insights.where((i) => i.type == InsightType.habit).toList()
-                    ..sort((a, b) => b.date.compareTo(a.date));
+              final habits = insights
+                  .where((i) => i.type == InsightType.habit)
+                  .toList()
+                ..sort((a, b) => b.date.compareTo(a.date));
 
-              final moods =
-                  insights.where((i) => i.type == InsightType.mood).toList()
-                    ..sort((a, b) => b.date.compareTo(a.date));
+              final moods = insights
+                  .where((i) => i.type == InsightType.mood)
+                  .toList()
+                ..sort((a, b) => b.date.compareTo(a.date));
 
-              final general =
-                  insights.where((i) => i.type == InsightType.general).toList()
-                    ..sort((a, b) => b.date.compareTo(a.date));
+              final general = insights
+                  .where((i) => i.type == InsightType.general)
+                  .toList()
+                ..sort((a, b) => b.date.compareTo(a.date));
 
               return RefreshIndicator(
                 onRefresh: () async {
-                  if (authState.isAuthenticated && authState.user != null) {
+                  if (authState.isAuthenticated &&
+                      authState.user != null) {
                     await ref
                         .read(dashboardProvider.notifier)
                         .loadInsights(
@@ -193,9 +199,12 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                       const SizedBox(height: 8),
                       DashboardStats(insights: insights),
                       const SizedBox(height: 8),
-                      MoodStreakCard(streak: streakState.currentStreak),
+                      MoodStreakCard(
+                        streak: streakState.currentStreak,
+                      ),
                       const SizedBox(height: 8),
-                      if (authState.isAuthenticated && authState.user != null)
+                      if (authState.isAuthenticated &&
+                          authState.user != null)
                         EchoBalanceCard(userId: authState.user!.id),
                       const SizedBox(height: 8),
                       MoodTrendChart(
@@ -209,7 +218,8 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                       InsightSection(
                         title: 'Predictions',
                         insights: predictions,
-                        icon: FontAwesomeIcons.wandMagicSparkles.data,
+                        icon: FontAwesomeIcons
+                            .wandMagicSparkles.data,
                         color: AppTheme.secondaryColor,
                       ),
                       InsightSection(
@@ -239,8 +249,9 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                 ),
               );
             },
-            loading: () =>
-                const Center(child: ShimmerLoading(width: 40, height: 40)),
+            loading: () => const Center(
+              child: ShimmerLoading(width: 40, height: 40),
+            ),
             error: (error, stack) => NoConnectionWidget(
               onRetry: () => ref.refresh(dashboardProvider),
             ),
@@ -274,7 +285,9 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Card(
         elevation: 2,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
         child: InkWell(
           onTap: () => context.push('/dashboard/mood-analytics'),
           borderRadius: BorderRadius.circular(16),
@@ -288,7 +301,10 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                     gradient: LinearGradient(
                       begin: Alignment.topLeft,
                       end: Alignment.bottomRight,
-                      colors: [AppTheme.accentColor, AppTheme.primaryColor],
+                      colors: [
+                        AppTheme.accentColor,
+                        AppTheme.primaryColor,
+                      ],
                     ),
                     borderRadius: BorderRadius.circular(12),
                   ),
@@ -313,9 +329,8 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                       Text(
                         'View trends, statistics, and insights',
                         style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurface.withValues(
-                            alpha: 0.6,
-                          ),
+                          color: theme.colorScheme.onSurface
+                              .withValues(alpha: 0.6),
                         ),
                       ),
                     ],
@@ -324,7 +339,8 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                 Icon(
                   FontAwesomeIcons.chevronRight.data,
                   size: 16,
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                  color: theme.colorScheme.onSurface
+                      .withValues(alpha: 0.5),
                 ),
               ],
             ),
@@ -359,12 +375,16 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                   gradient: LinearGradient(
                     begin: Alignment.topLeft,
                     end: Alignment.bottomRight,
-                    colors: [AppTheme.primaryColor, AppTheme.secondaryColor],
+                    colors: [
+                      AppTheme.primaryColor,
+                      AppTheme.secondaryColor,
+                    ],
                   ),
                   shape: BoxShape.circle,
                   boxShadow: [
                     BoxShadow(
-                      color: AppTheme.primaryColor.withValues(alpha: 0.3),
+                      color: AppTheme.primaryColor
+                          .withValues(alpha: 0.3),
                       blurRadius: 30,
                       offset: const Offset(0, 10),
                     ),
@@ -388,9 +408,12 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
               ),
               const SizedBox(height: 16),
               Text(
-                'Start logging your daily activities, moods, and habits to see personalized insights and AI-powered predictions generated by Gemini.',
+                'Start logging your daily activities, moods, and habits '
+                'to see personalized insights and AI-powered predictions '
+                'generated by Gemini.',
                 style: theme.textTheme.bodyLarge?.copyWith(
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                  color: theme.colorScheme.onSurface
+                      .withValues(alpha: 0.6),
                   height: 1.6,
                   fontSize: 15,
                 ),
@@ -402,12 +425,16 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                   gradient: const LinearGradient(
                     begin: Alignment.topLeft,
                     end: Alignment.bottomRight,
-                    colors: [AppTheme.primaryColor, AppTheme.secondaryColor],
+                    colors: [
+                      AppTheme.primaryColor,
+                      AppTheme.secondaryColor,
+                    ],
                   ),
                   borderRadius: BorderRadius.circular(16),
                   boxShadow: [
                     BoxShadow(
-                      color: AppTheme.primaryColor.withValues(alpha: 0.4),
+                      color: AppTheme.primaryColor
+                          .withValues(alpha: 0.4),
                       blurRadius: 20,
                       offset: const Offset(0, 8),
                     ),
@@ -491,16 +518,13 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
         final currentEntries = ref.read(loggingProvider).value ?? [];
 
         final matchingEntry = currentEntries.firstWhere((entry) {
-          final localDate = entry.date.isUtc
-              ? entry.date.toLocal()
-              : entry.date;
-
+          final localDate =
+              entry.date.isUtc ? entry.date.toLocal() : entry.date;
           final entryDate = DateTime(
             localDate.year,
             localDate.month,
             localDate.day,
           );
-
           return entryDate.isAtSameMomentAs(insightDate);
         });
 
@@ -515,7 +539,8 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(
-                'No log entry found for ${DateFormatter.formatDate(insight.date)}. '
+                'No log entry found for '
+                '${DateFormatter.formatDate(insight.date)}. '
                 'Would you like to create one?',
               ),
               duration: const Duration(seconds: 3),

--- a/lib/features/dashboard/view/widgets/daily_log_status_banner.dart
+++ b/lib/features/dashboard/view/widgets/daily_log_status_banner.dart
@@ -17,7 +17,8 @@ class DailyLogStatusBanner extends ConsumerWidget {
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
 
-    final LogEntryModel? todayEntry = entries.cast<LogEntryModel?>().firstWhere(
+    final LogEntryModel? todayEntry =
+        entries.cast<LogEntryModel?>().firstWhere(
       (e) {
         if (e == null) return false;
         final local = e.date.isUtc ? e.date.toLocal() : e.date;
@@ -35,7 +36,10 @@ class DailyLogStatusBanner extends ConsumerWidget {
           borderRadius: BorderRadius.circular(16),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          padding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 8,
+          ),
           child: Row(
             children: [
               const Icon(
@@ -44,7 +48,7 @@ class DailyLogStatusBanner extends ConsumerWidget {
                 size: 22,
               ),
               const SizedBox(width: 10),
-              Text(
+              const Text(
                 '✓ Logged today',
                 style: TextStyle(
                   color: AppTheme.successColor,

--- a/lib/features/dashboard/view/widgets/daily_log_status_banner.dart
+++ b/lib/features/dashboard/view/widgets/daily_log_status_banner.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/themes/app_theme.dart';
+import '../../../logging/data/models/log_entry_model.dart';
+import '../../../logging/viewmodel/providers/logging_provider.dart';
+
+/// A compact banner shown on the dashboard when the user has already
+/// logged today. Displays a success indicator and a "View log →" button.
+class DailyLogStatusBanner extends ConsumerWidget {
+  const DailyLogStatusBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final entries = ref.watch(loggingProvider).value ?? [];
+
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    final LogEntryModel? todayEntry = entries.cast<LogEntryModel?>().firstWhere(
+      (e) {
+        if (e == null) return false;
+        final local = e.date.isUtc ? e.date.toLocal() : e.date;
+        final d = DateTime(local.year, local.month, local.day);
+        return d.isAtSameMomentAs(today);
+      },
+      orElse: () => null,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Card(
+        elevation: 2,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              const Icon(
+                Icons.check_circle,
+                color: AppTheme.successColor,
+                size: 22,
+              ),
+              const SizedBox(width: 10),
+              Text(
+                '✓ Logged today',
+                style: TextStyle(
+                  color: AppTheme.successColor,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const Spacer(),
+              TextButton(
+                onPressed: () {
+                  if (todayEntry != null) {
+                    context.push(
+                      '/logging/detail/${todayEntry.id}',
+                      extra: todayEntry,
+                    );
+                  } else {
+                    context.push('/logging/create');
+                  }
+                },
+                child: const Text('View log →'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/view/widgets/quick_check_in_widget.dart
+++ b/lib/features/dashboard/view/widgets/quick_check_in_widget.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/themes/app_theme.dart';
+import '../../../auth/viewmodel/providers/auth_provider.dart';
+import '../../../logging/data/models/log_entry_model.dart';
+import '../../../logging/data/models/quick_check_in_data.dart';
+import '../../../logging/viewmodel/providers/logging_provider.dart';
+
+// ---------------------------------------------------------------------------
+// Internal state enum
+// ---------------------------------------------------------------------------
+
+enum _WidgetState { idle, submitting, confirming }
+
+// ---------------------------------------------------------------------------
+// Widget
+// ---------------------------------------------------------------------------
+
+class QuickCheckInWidget extends ConsumerStatefulWidget {
+  const QuickCheckInWidget({super.key});
+
+  @override
+  ConsumerState<QuickCheckInWidget> createState() => _QuickCheckInWidgetState();
+}
+
+class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
+  // ── State fields ──────────────────────────────────────────────────────────
+  int? _selectedMood;
+  final TextEditingController _noteController = TextEditingController();
+  _WidgetState _state = _WidgetState.idle;
+  String? _errorMessage;
+
+  // ── Emoji map ─────────────────────────────────────────────────────────────
+  static const Map<int, String> _moodEmojis = {
+    1: '😞',
+    2: '😕',
+    3: '😐',
+    4: '🙂',
+    5: '😄',
+  };
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+  @override
+  void dispose() {
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  String? get _trimmedNote {
+    final trimmed = _noteController.text.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
+  // ── Submit handler ────────────────────────────────────────────────────────
+
+  Future<void> _handleSubmit() async {
+    if (_selectedMood == null || _state != _WidgetState.idle) return;
+
+    setState(() {
+      _state = _WidgetState.submitting;
+      _errorMessage = null;
+    });
+
+    final auth = ref.read(authProvider);
+    if (auth.user == null) {
+      setState(() {
+        _state = _WidgetState.idle;
+        _errorMessage = 'Please log in first.';
+      });
+      return;
+    }
+
+    final now = DateTime.now();
+    final entry = LogEntryModel(
+      id: now.millisecondsSinceEpoch.toString(),
+      userId: auth.user!.id,
+      date: DateTime.utc(now.year, now.month, now.day),
+      mood: _selectedMood,
+      notes: _trimmedNote,
+      habits: const [],
+      createdAt: now,
+    );
+
+    final success =
+        await ref.read(loggingProvider.notifier).createLogEntry(entry);
+
+    if (!mounted) return;
+
+    if (success) {
+      setState(() {
+        _state = _WidgetState.confirming;
+      });
+    } else {
+      setState(() {
+        _state = _WidgetState.idle;
+        _errorMessage = 'Something went wrong. Please try again.';
+      });
+    }
+  }
+
+  // ── Build ─────────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Card(
+        elevation: 2,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // ── Card title ───────────────────────────────────────────────
+              Text(
+                'How are you feeling today?',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+
+              // ── Confirming state replaces body ───────────────────────────
+              if (_state == _WidgetState.confirming) ...[
+                const SizedBox(height: 16),
+                Center(
+                  child: Text(
+                    'Logged! +1 ECHO earned 🎉',
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: AppTheme.successColor,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 16,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(height: 16),
+              ] else ...[
+                // ── Mood emoji row ───────────────────────────────────────
+                _buildMoodRow(theme),
+                const SizedBox(height: 16),
+
+                // ── Note text field ──────────────────────────────────────
+                TextField(
+                  controller: _noteController,
+                  maxLength: 120,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    labelText: 'One thing on your mind?',
+                  ),
+                ),
+                const SizedBox(height: 16),
+
+                // ── "Log it" button ──────────────────────────────────────
+                ElevatedButton(
+                  onPressed: (_selectedMood == null ||
+                          _state != _WidgetState.idle)
+                      ? null
+                      : _handleSubmit,
+                  child: _state == _WidgetState.submitting
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : const Text('Log it'),
+                ),
+
+                // ── Error message ────────────────────────────────────────
+                if (_errorMessage != null) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    _errorMessage!,
+                    style: const TextStyle(
+                      color: AppTheme.errorColor,
+                      fontSize: 13,
+                    ),
+                  ),
+                ],
+
+                const SizedBox(height: 4),
+
+                // ── "Add more detail →" link ─────────────────────────────
+                if (_state == _WidgetState.idle)
+                  TextButton(
+                    onPressed: () {
+                      context.push(
+                        '/logging/create',
+                        extra: QuickCheckInData(
+                          mood: _selectedMood,
+                          note: _trimmedNote,
+                        ),
+                      );
+                    },
+                    child: const Text('Add more detail →'),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ── Mood emoji row builder ────────────────────────────────────────────────
+
+  Widget _buildMoodRow(ThemeData theme) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: _moodEmojis.entries.map((entry) {
+        final moodValue = entry.key;
+        final emoji = entry.value;
+        final isSelected = _selectedMood == moodValue;
+
+        return GestureDetector(
+          onTap: () {
+            setState(() {
+              _selectedMood = isSelected ? null : moodValue;
+            });
+          },
+          child: Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              color: isSelected
+                  ? AppTheme.accentColor.withValues(alpha: 0.2)
+                  : theme.colorScheme.surface,
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: isSelected
+                    ? AppTheme.accentColor
+                    : theme.colorScheme.outline.withValues(alpha: 0.3),
+                width: isSelected ? 2.0 : 1.0,
+              ),
+            ),
+            child: Center(
+              child: Text(
+                emoji,
+                style: TextStyle(
+                  fontSize: 26,
+                  color: isSelected
+                      ? AppTheme.accentColor
+                      : theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+              ),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/features/dashboard/view/widgets/quick_check_in_widget.dart
+++ b/lib/features/dashboard/view/widgets/quick_check_in_widget.dart
@@ -7,31 +7,24 @@ import '../../../logging/data/models/log_entry_model.dart';
 import '../../../logging/data/models/quick_check_in_data.dart';
 import '../../../logging/viewmodel/providers/logging_provider.dart';
 
-// ---------------------------------------------------------------------------
-// Internal state enum
-// ---------------------------------------------------------------------------
-
 enum _WidgetState { idle, submitting, confirming }
 
-// ---------------------------------------------------------------------------
-// Widget
-// ---------------------------------------------------------------------------
-
+/// A quick mood check-in card shown at the top of the dashboard
+/// when the user has not yet logged today.
 class QuickCheckInWidget extends ConsumerStatefulWidget {
   const QuickCheckInWidget({super.key});
 
   @override
-  ConsumerState<QuickCheckInWidget> createState() => _QuickCheckInWidgetState();
+  ConsumerState<QuickCheckInWidget> createState() =>
+      _QuickCheckInWidgetState();
 }
 
 class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
-  // ── State fields ──────────────────────────────────────────────────────────
   int? _selectedMood;
   final TextEditingController _noteController = TextEditingController();
   _WidgetState _state = _WidgetState.idle;
   String? _errorMessage;
 
-  // ── Emoji map ─────────────────────────────────────────────────────────────
   static const Map<int, String> _moodEmojis = {
     1: '😞',
     2: '😕',
@@ -40,21 +33,16 @@ class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
     5: '😄',
   };
 
-  // ── Lifecycle ─────────────────────────────────────────────────────────────
   @override
   void dispose() {
     _noteController.dispose();
     super.dispose();
   }
 
-  // ── Helpers ───────────────────────────────────────────────────────────────
-
   String? get _trimmedNote {
     final trimmed = _noteController.text.trim();
     return trimmed.isEmpty ? null : trimmed;
   }
-
-  // ── Submit handler ────────────────────────────────────────────────────────
 
   Future<void> _handleSubmit() async {
     if (_selectedMood == null || _state != _WidgetState.idle) return;
@@ -101,8 +89,6 @@ class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
     }
   }
 
-  // ── Build ─────────────────────────────────────────────────────────────────
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -119,7 +105,6 @@ class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // ── Card title ───────────────────────────────────────────────
               Text(
                 'How are you feeling today?',
                 style: theme.textTheme.titleMedium?.copyWith(
@@ -127,8 +112,6 @@ class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
                 ),
               ),
               const SizedBox(height: 8),
-
-              // ── Confirming state replaces body ───────────────────────────
               if (_state == _WidgetState.confirming) ...[
                 const SizedBox(height: 16),
                 Center(
@@ -144,11 +127,8 @@ class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
                 ),
                 const SizedBox(height: 16),
               ] else ...[
-                // ── Mood emoji row ───────────────────────────────────────
                 _buildMoodRow(theme),
                 const SizedBox(height: 16),
-
-                // ── Note text field ──────────────────────────────────────
                 TextField(
                   controller: _noteController,
                   maxLength: 120,
@@ -158,13 +138,11 @@ class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
                   ),
                 ),
                 const SizedBox(height: 16),
-
-                // ── "Log it" button ──────────────────────────────────────
                 ElevatedButton(
-                  onPressed: (_selectedMood == null ||
-                          _state != _WidgetState.idle)
-                      ? null
-                      : _handleSubmit,
+                  onPressed:
+                      (_selectedMood == null || _state != _WidgetState.idle)
+                          ? null
+                          : _handleSubmit,
                   child: _state == _WidgetState.submitting
                       ? const SizedBox(
                           width: 20,
@@ -176,8 +154,6 @@ class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
                         )
                       : const Text('Log it'),
                 ),
-
-                // ── Error message ────────────────────────────────────────
                 if (_errorMessage != null) ...[
                   const SizedBox(height: 8),
                   Text(
@@ -188,10 +164,7 @@ class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
                     ),
                   ),
                 ],
-
                 const SizedBox(height: 4),
-
-                // ── "Add more detail →" link ─────────────────────────────
                 if (_state == _WidgetState.idle)
                   TextButton(
                     onPressed: () {
@@ -212,8 +185,6 @@ class _QuickCheckInWidgetState extends ConsumerState<QuickCheckInWidget> {
       ),
     );
   }
-
-  // ── Mood emoji row builder ────────────────────────────────────────────────
 
   Widget _buildMoodRow(ThemeData theme) {
     return Row(

--- a/lib/features/dashboard/viewmodel/providers/has_logged_today_provider.dart
+++ b/lib/features/dashboard/viewmodel/providers/has_logged_today_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../logging/viewmodel/providers/logging_provider.dart';
+
+/// Returns true when loggingProvider contains at least one entry
+/// whose date (in local timezone) matches today's local calendar date.
+/// Returns false while loading, on error, or when no entry exists for today.
+final hasLoggedTodayProvider = Provider<bool>((ref) {
+  final loggingState = ref.watch(loggingProvider);
+
+  return loggingState.when(
+    data: (entries) {
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      return entries.any((entry) {
+        final local = entry.date.isUtc ? entry.date.toLocal() : entry.date;
+        final d = DateTime(local.year, local.month, local.day);
+        return d.isAtSameMomentAs(today);
+      });
+    },
+    loading: () => false,
+    error: (_, __) => false,
+  );
+});

--- a/lib/features/dashboard/viewmodel/providers/has_logged_today_provider.dart
+++ b/lib/features/dashboard/viewmodel/providers/has_logged_today_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../logging/viewmodel/providers/logging_provider.dart';
 
-/// Returns true when loggingProvider contains at least one entry
+/// Returns true when [loggingProvider] contains at least one entry
 /// whose date (in local timezone) matches today's local calendar date.
 /// Returns false while loading, on error, or when no entry exists for today.
 final hasLoggedTodayProvider = Provider<bool>((ref) {
@@ -12,7 +12,8 @@ final hasLoggedTodayProvider = Provider<bool>((ref) {
       final now = DateTime.now();
       final today = DateTime(now.year, now.month, now.day);
       return entries.any((entry) {
-        final local = entry.date.isUtc ? entry.date.toLocal() : entry.date;
+        final local =
+            entry.date.isUtc ? entry.date.toLocal() : entry.date;
         final d = DateTime(local.year, local.month, local.day);
         return d.isAtSameMomentAs(today);
       });

--- a/lib/features/logging/data/models/quick_check_in_data.dart
+++ b/lib/features/logging/data/models/quick_check_in_data.dart
@@ -1,7 +1,11 @@
-/// Data passed from QuickCheckInWidget to CreateEntryScreen via go_router extra.
+/// Data passed from QuickCheckInWidget to CreateEntryScreen
+/// via go_router extra.
 class QuickCheckInData {
   const QuickCheckInData({this.mood, this.note});
 
-  final int? mood; // 1–5, or null if none selected
-  final String? note; // trimmed, or null if empty
+  /// Mood value 1–5, or null if none selected.
+  final int? mood;
+
+  /// Note text (trimmed), or null if empty.
+  final String? note;
 }

--- a/lib/features/logging/data/models/quick_check_in_data.dart
+++ b/lib/features/logging/data/models/quick_check_in_data.dart
@@ -1,0 +1,7 @@
+/// Data passed from QuickCheckInWidget to CreateEntryScreen via go_router extra.
+class QuickCheckInData {
+  const QuickCheckInData({this.mood, this.note});
+
+  final int? mood; // 1–5, or null if none selected
+  final String? note; // trimmed, or null if empty
+}

--- a/lib/features/logging/view/screens/create_entry_screen.dart
+++ b/lib/features/logging/view/screens/create_entry_screen.dart
@@ -14,14 +14,16 @@ import '../../viewmodel/providers/logging_provider.dart';
 import '../widgets/voice_input_button.dart';
 import '../../../global_mirror/viewmodel/providers/global_mirror_provider.dart';
 
-/// Screen for creating a new log entry
+/// Screen for creating a new log entry.
 class CreateEntryScreen extends ConsumerStatefulWidget {
   const CreateEntryScreen({super.key, this.prefill});
 
+  /// Optional prefill data from the quick check-in widget.
   final QuickCheckInData? prefill;
 
   @override
-  ConsumerState<CreateEntryScreen> createState() => _CreateEntryScreenState();
+  ConsumerState<CreateEntryScreen> createState() =>
+      _CreateEntryScreenState();
 }
 
 class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
@@ -42,7 +44,8 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
     super.initState();
     if (widget.prefill != null) {
       _selectedMood = widget.prefill!.mood;
-      if (widget.prefill!.note != null && widget.prefill!.note!.isNotEmpty) {
+      if (widget.prefill!.note != null &&
+          widget.prefill!.note!.isNotEmpty) {
         _notesController.text = widget.prefill!.note!;
       }
     }
@@ -99,9 +102,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
   }
 
   Future<void> _handleSubmit() async {
-    if (!_formKey.currentState!.validate()) {
-      return;
-    }
+    if (!_formKey.currentState!.validate()) return;
 
     final authState = ref.read(authProvider);
     if (!authState.isAuthenticated || authState.user == null) {
@@ -121,8 +122,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
     });
 
     try {
-      // Create log entry model
-      // Use UTC for date to avoid timezone issues - dates are date-only values
+      // Use UTC for date to avoid timezone issues — dates are date-only.
       final entry = LogEntryModel(
         id: DateTime.now().millisecondsSinceEpoch.toString(),
         userId: authState.user!.id,
@@ -139,81 +139,89 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
         createdAt: DateTime.now(),
       );
 
-      final success = await ref
-          .read(loggingProvider.notifier)
-          .createLogEntry(entry);
+      final success =
+          await ref.read(loggingProvider.notifier).createLogEntry(entry);
 
       if (mounted) {
         if (success) {
           ErrorHandler.showSuccess(context, 'Entry created successfully!');
 
-          // Share mood anonymously if opted in
+          // Share mood anonymously if opted in.
           if (_shareAnonymously && _selectedMood != null) {
             debugPrint(
-              '[CreateEntryScreen] Sharing mood anonymously: mood=$_selectedMood, shareAnonymously=$_shareAnonymously',
+              '[CreateEntryScreen] Sharing mood anonymously: '
+              'mood=$_selectedMood, '
+              'shareAnonymously=$_shareAnonymously',
             );
             final sentiment = _getMoodSentiment(_selectedMood!);
             debugPrint(
-              '[CreateEntryScreen] Mapped mood $_selectedMood to sentiment: $sentiment',
+              '[CreateEntryScreen] Mapped mood $_selectedMood '
+              'to sentiment: $sentiment',
             );
             final shareResult = await ref
                 .read(globalMirrorProvider.notifier)
                 .shareMood(sentiment);
-            debugPrint('[CreateEntryScreen] Share mood result: $shareResult');
+            debugPrint(
+              '[CreateEntryScreen] Share mood result: $shareResult',
+            );
             if (!shareResult && mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: const Text(
-                    'Failed to share mood. Check location permissions.',
+                const SnackBar(
+                  content: Text(
+                    'Failed to share mood. '
+                    'Check location permissions.',
                   ),
                   backgroundColor: Colors.orange,
-                  duration: const Duration(seconds: 3),
+                  duration: Duration(seconds: 3),
                 ),
               );
             }
           } else {
             debugPrint(
-              '[CreateEntryScreen] Not sharing mood: shareAnonymously=$_shareAnonymously, selectedMood=$_selectedMood',
+              '[CreateEntryScreen] Not sharing mood: '
+              'shareAnonymously=$_shareAnonymously, '
+              'selectedMood=$_selectedMood',
             );
           }
 
-          // Trigger AI insight generation if we have at least 3 logs
+          // Trigger AI insight generation if we have at least 3 logs.
           final loggingState = ref.read(loggingProvider);
           final allLogs = loggingState.value ?? [];
           if (allLogs.length >= 3) {
-            // Get recent logs (last 7-14 days)
             final now = DateTime.now();
-            final recentLogs =
-                allLogs
-                    .where(
-                      (log) => log.date.isAfter(
-                        now.subtract(const Duration(days: 14)),
-                      ),
-                    )
-                    .toList()
-                  ..sort((a, b) => b.date.compareTo(a.date));
+            final recentLogs = allLogs
+                .where(
+                  (log) => log.date.isAfter(
+                    now.subtract(const Duration(days: 14)),
+                  ),
+                )
+                .toList()
+              ..sort((a, b) => b.date.compareTo(a.date));
 
             if (recentLogs.length >= 3) {
-              // Trigger insight generation (don't await - let it run in background)
-              ref.read(aiInsightProvider.notifier).generateInsight(recentLogs);
+              // Don't await — let it run in background.
+              ref
+                  .read(aiInsightProvider.notifier)
+                  .generateInsight(recentLogs);
             }
           }
 
           if (!mounted) return;
           Navigator.of(context).pop();
         } else {
-          // Get error message from provider state
           final loggingState = ref.read(loggingProvider);
           final errorMessage = loggingState.hasError
               ? ErrorHandler.getErrorMessage(loggingState.error!)
               : 'Failed to create entry. Please try again.';
-
           ErrorHandler.showError(context, errorMessage);
         }
       }
     } catch (e) {
       if (mounted) {
-        ErrorHandler.showError(context, ErrorHandler.getErrorMessage(e));
+        ErrorHandler.showError(
+          context,
+          ErrorHandler.getErrorMessage(e),
+        );
       }
     } finally {
       if (mounted) {
@@ -240,37 +248,40 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    // Header icon
-                    Container(
-                      width: 80,
-                      height: 80,
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topLeft,
-                          end: Alignment.bottomRight,
-                          colors: [
-                            AppTheme.primaryColor,
-                            AppTheme.secondaryColor,
+                    // Header icon.
+                    Center(
+                      child: Container(
+                        width: 80,
+                        height: 80,
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topLeft,
+                            end: Alignment.bottomRight,
+                            colors: [
+                              AppTheme.primaryColor,
+                              AppTheme.secondaryColor,
+                            ],
+                          ),
+                          shape: BoxShape.circle,
+                          boxShadow: [
+                            BoxShadow(
+                              color: AppTheme.primaryColor
+                                  .withValues(alpha: 0.3),
+                              blurRadius: 20,
+                              offset: const Offset(0, 8),
+                            ),
                           ],
                         ),
-                        shape: BoxShape.circle,
-                        boxShadow: [
-                          BoxShadow(
-                            color: AppTheme.primaryColor.withValues(alpha: 0.3),
-                            blurRadius: 20,
-                            offset: const Offset(0, 8),
-                          ),
-                        ],
-                      ),
-                      child: Icon(
-                        FontAwesomeIcons.pen.data,
-                        size: 36,
-                        color: Colors.white,
+                        child: Icon(
+                          FontAwesomeIcons.pen.data,
+                          size: 36,
+                          color: Colors.white,
+                        ),
                       ),
                     ),
                     const SizedBox(height: 24),
 
-                    // Date picker section
+                    // Date picker section.
                     Card(
                       elevation: 2,
                       shape: RoundedRectangleBorder(
@@ -286,10 +297,10 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                               Container(
                                 padding: const EdgeInsets.all(12),
                                 decoration: BoxDecoration(
-                                  color: AppTheme.primaryColor.withValues(
-                                    alpha: 0.1,
-                                  ),
-                                  borderRadius: BorderRadius.circular(12),
+                                  color: AppTheme.primaryColor
+                                      .withValues(alpha: 0.1),
+                                  borderRadius:
+                                      BorderRadius.circular(12),
                                 ),
                                 child: Icon(
                                   FontAwesomeIcons.calendar.data,
@@ -300,25 +311,28 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                               const SizedBox(width: 16),
                               Expanded(
                                 child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.start,
                                   children: [
                                     Text(
                                       'Date',
                                       style: theme.textTheme.labelMedium
                                           ?.copyWith(
-                                            color: theme.colorScheme.onSurface
-                                                .withValues(alpha: 0.6),
-                                          ),
+                                        color: theme
+                                            .colorScheme.onSurface
+                                            .withValues(alpha: 0.6),
+                                      ),
                                     ),
                                     const SizedBox(height: 4),
                                     Text(
                                       DateFormatter.formatDateLong(
                                         _selectedDate,
                                       ),
-                                      style: theme.textTheme.titleMedium
+                                      style: theme
+                                          .textTheme.titleMedium
                                           ?.copyWith(
-                                            fontWeight: FontWeight.w600,
-                                          ),
+                                        fontWeight: FontWeight.w600,
+                                      ),
                                     ),
                                   ],
                                 ),
@@ -326,9 +340,8 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                               Icon(
                                 FontAwesomeIcons.chevronRight.data,
                                 size: 16,
-                                color: theme.colorScheme.onSurface.withValues(
-                                  alpha: 0.5,
-                                ),
+                                color: theme.colorScheme.onSurface
+                                    .withValues(alpha: 0.5),
                               ),
                             ],
                           ),
@@ -337,7 +350,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                     ),
                     const SizedBox(height: 24),
 
-                    // Mood selection section
+                    // Mood selection section.
                     Text(
                       'How are you feeling?',
                       style: theme.textTheme.titleMedium?.copyWith(
@@ -353,14 +366,18 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                       child: Padding(
                         padding: const EdgeInsets.all(16),
                         child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
+                          mainAxisAlignment:
+                              MainAxisAlignment.spaceAround,
                           children: List.generate(5, (index) {
                             final moodValue = index + 1;
-                            final isSelected = _selectedMood == moodValue;
+                            final isSelected =
+                                _selectedMood == moodValue;
                             return GestureDetector(
                               onTap: () {
                                 setState(() {
-                                  _selectedMood = isSelected ? null : moodValue;
+                                  _selectedMood = isSelected
+                                      ? null
+                                      : moodValue;
                                 });
                               },
                               child: Container(
@@ -368,17 +385,15 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                                 height: 56,
                                 decoration: BoxDecoration(
                                   color: isSelected
-                                      ? AppTheme.accentColor.withValues(
-                                          alpha: 0.2,
-                                        )
+                                      ? AppTheme.accentColor
+                                          .withValues(alpha: 0.2)
                                       : theme.colorScheme.surface,
                                   shape: BoxShape.circle,
                                   border: Border.all(
                                     color: isSelected
                                         ? AppTheme.accentColor
-                                        : theme.colorScheme.outline.withValues(
-                                            alpha: 0.3,
-                                          ),
+                                        : theme.colorScheme.outline
+                                            .withValues(alpha: 0.3),
                                     width: isSelected ? 2 : 1,
                                   ),
                                 ),
@@ -387,9 +402,8 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                                   size: 28,
                                   color: isSelected
                                       ? AppTheme.accentColor
-                                      : theme.colorScheme.onSurface.withValues(
-                                          alpha: 0.6,
-                                        ),
+                                      : theme.colorScheme.onSurface
+                                          .withValues(alpha: 0.6),
                                 ),
                               ),
                             );
@@ -410,7 +424,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                     ],
                     const SizedBox(height: 24),
 
-                    // Habits section
+                    // Habits section.
                     Text(
                       'Habits',
                       style: theme.textTheme.titleMedium?.copyWith(
@@ -446,7 +460,10 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                               borderRadius: BorderRadius.circular(12),
                             ),
                           ),
-                          child: Icon(FontAwesomeIcons.plus.data, size: 18),
+                          child: Icon(
+                            FontAwesomeIcons.plus.data,
+                            size: 18,
+                          ),
                         ),
                       ],
                     ),
@@ -463,10 +480,9 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                               FontAwesomeIcons.xmark.data,
                               size: 16,
                             ),
-                            backgroundColor: AppTheme.primaryColor.withValues(
-                              alpha: 0.1,
-                            ),
-                            labelStyle: TextStyle(
+                            backgroundColor: AppTheme.primaryColor
+                                .withValues(alpha: 0.1),
+                            labelStyle: const TextStyle(
                               color: AppTheme.primaryColor,
                               fontWeight: FontWeight.w600,
                             ),
@@ -476,9 +492,10 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                     ],
                     const SizedBox(height: 24),
 
-                    // Notes section
+                    // Notes section.
                     Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      mainAxisAlignment:
+                          MainAxisAlignment.spaceBetween,
                       children: [
                         Text(
                           'Notes (Optional)',
@@ -486,11 +503,10 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                             fontWeight: FontWeight.w600,
                           ),
                         ),
-                        // Voice input hint
                         if (!_isListening)
                           TextButton.icon(
                             onPressed: () {
-                              // Voice button will handle this
+                              // Voice button will handle this.
                             },
                             icon: Icon(
                               FontAwesomeIcons.microphone.data,
@@ -509,7 +525,8 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                       maxLines: 5,
                       decoration: InputDecoration(
                         hintText:
-                            'Write about your day, thoughts, or anything else...',
+                            'Write about your day, thoughts, or '
+                            'anything else...',
                         prefixIcon: Icon(
                           FontAwesomeIcons.noteSticky.data,
                           size: 18,
@@ -517,7 +534,10 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                         suffixIcon: _isListening
                             ? const Padding(
                                 padding: EdgeInsets.all(12),
-                                child: ShimmerLoading(width: 20, height: 20),
+                                child: ShimmerLoading(
+                                  width: 20,
+                                  height: 20,
+                                ),
                               )
                             : null,
                         border: OutlineInputBorder(
@@ -527,22 +547,23 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                     ),
                     const SizedBox(height: 24),
 
-                    // Anonymous sharing opt-in - Made more prominent
+                    // Anonymous sharing opt-in.
                     if (_selectedMood != null)
                       Container(
                         padding: const EdgeInsets.all(16),
                         decoration: BoxDecoration(
-                          color: AppTheme.primaryColor.withValues(alpha: 0.1),
+                          color: AppTheme.primaryColor
+                              .withValues(alpha: 0.1),
                           borderRadius: BorderRadius.circular(12),
                           border: Border.all(
-                            color: AppTheme.primaryColor.withValues(alpha: 0.5),
+                            color: AppTheme.primaryColor
+                                .withValues(alpha: 0.5),
                             width: 2,
                           ),
                           boxShadow: [
                             BoxShadow(
-                              color: AppTheme.primaryColor.withValues(
-                                alpha: 0.1,
-                              ),
+                              color: AppTheme.primaryColor
+                                  .withValues(alpha: 0.1),
                               blurRadius: 8,
                               spreadRadius: 2,
                             ),
@@ -561,7 +582,8 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                             ),
                             Expanded(
                               child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
+                                crossAxisAlignment:
+                                    CrossAxisAlignment.start,
                                 children: [
                                   Row(
                                     children: [
@@ -574,19 +596,25 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                                       Expanded(
                                         child: Text(
                                           'Share mood on Global Mirror',
-                                          style: theme.textTheme.bodyLarge
+                                          style: theme
+                                              .textTheme.bodyLarge
                                               ?.copyWith(
-                                                fontWeight: FontWeight.w700,
-                                                color: AppTheme.primaryColor,
-                                              ),
+                                            fontWeight: FontWeight.w700,
+                                            color: AppTheme.primaryColor,
+                                          ),
                                         ),
                                       ),
                                     ],
                                   ),
                                   const SizedBox(height: 6),
                                   Text(
-                                    'Help the global community by sharing your mood anonymously. Your location is anonymized (~11km) and data expires in 24 hours.',
-                                    style: theme.textTheme.bodySmall?.copyWith(
+                                    'Help the global community by '
+                                    'sharing your mood anonymously. '
+                                    'Your location is anonymized '
+                                    '(~11km) and data expires in '
+                                    '24 hours.',
+                                    style: theme.textTheme.bodySmall
+                                        ?.copyWith(
                                       color: theme.colorScheme.onSurface
                                           .withValues(alpha: 0.7),
                                     ),
@@ -604,15 +632,22 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                                 showDialog(
                                   context: context,
                                   builder: (context) => AlertDialog(
-                                    title: const Text('Anonymous Sharing'),
+                                    title: const Text(
+                                      'Anonymous Sharing',
+                                    ),
                                     content: const Text(
-                                      'When enabled, your mood will be shared anonymously on the Global Mirror map. '
-                                      'Your location is anonymized to ~11km precision and no personal information is stored. '
-                                      'All shared data expires after 24 hours.',
+                                      'When enabled, your mood will be '
+                                      'shared anonymously on the Global '
+                                      'Mirror map. Your location is '
+                                      'anonymized to ~11km precision and '
+                                      'no personal information is stored. '
+                                      'All shared data expires after '
+                                      '24 hours.',
                                     ),
                                     actions: [
                                       TextButton(
-                                        onPressed: () => Navigator.pop(context),
+                                        onPressed: () =>
+                                            Navigator.pop(context),
                                         child: const Text('Got It'),
                                       ),
                                     ],
@@ -625,7 +660,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                       ),
                     const SizedBox(height: 32),
 
-                    // Submit button
+                    // Submit button.
                     CustomButton(
                       onPressed: _isSubmitting ? null : _handleSubmit,
                       text: 'Create Entry',
@@ -638,7 +673,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
               ),
             ),
           ),
-          // Voice input overlay
+          // Voice input overlay.
           if (_isListening)
             VoiceInputOverlay(
               isListening: _isListening,
@@ -649,7 +684,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                 });
               },
             ),
-          // Floating voice input button
+          // Floating voice input button.
           Positioned(
             bottom: 24,
             right: 24,
@@ -665,7 +700,6 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                   _voiceTranscription = transcription;
                   _isListening = false;
                 });
-                // Append to existing notes if any
                 if (_notesController.text.isNotEmpty &&
                     transcription.isNotEmpty) {
                   _notesController.text =

--- a/lib/features/logging/view/screens/create_entry_screen.dart
+++ b/lib/features/logging/view/screens/create_entry_screen.dart
@@ -9,13 +9,16 @@ import '../../../auth/viewmodel/providers/auth_provider.dart';
 import '../../../auth/view/widgets/custom_button.dart';
 import '../../../ai/viewmodel/providers/ai_provider.dart';
 import '../../data/models/log_entry_model.dart';
+import '../../data/models/quick_check_in_data.dart';
 import '../../viewmodel/providers/logging_provider.dart';
 import '../widgets/voice_input_button.dart';
 import '../../../global_mirror/viewmodel/providers/global_mirror_provider.dart';
 
 /// Screen for creating a new log entry
 class CreateEntryScreen extends ConsumerStatefulWidget {
-  const CreateEntryScreen({super.key});
+  const CreateEntryScreen({super.key, this.prefill});
+
+  final QuickCheckInData? prefill;
 
   @override
   ConsumerState<CreateEntryScreen> createState() => _CreateEntryScreenState();
@@ -33,6 +36,17 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
   bool _isListening = false;
   String _voiceTranscription = '';
   bool _shareAnonymously = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.prefill != null) {
+      _selectedMood = widget.prefill!.mood;
+      if (widget.prefill!.note != null && widget.prefill!.note!.isNotEmpty) {
+        _notesController.text = widget.prefill!.note!;
+      }
+    }
+  }
 
   @override
   void dispose() {


### PR DESCRIPTION
## Summary
Adds a `QuickCheckInWidget` to the dashboard so users can log their daily mood in seconds without navigating to the full log form, reducing friction and increasing daily log completion rates.

## Changes

### New Files
- `lib/features/dashboard/view/widgets/quick_check_in_widget.dart` — mood emoji row (😞😕😐🙂😄), optional note input (max 120 chars), "Log it" button with loading state, inline "Logged! +1 ECHO earned 🎉" confirmation for 3 seconds, "Add more detail →" link
- `lib/features/dashboard/view/widgets/daily_log_status_banner.dart` — compact "✓ Logged today" card shown when user has already logged
- `lib/features/dashboard/viewmodel/providers/has_logged_today_provider.dart` — derived Provider<bool> watching loggingProvider, checks if any entry matches today's date
- `lib/features/logging/data/models/quick_check_in_data.dart` — data class carrying mood and note between widget and CreateEntryScreen

### Modified Files
- `lib/features/dashboard/view/screens/dashboard_screen.dart` — watches `hasLoggedTodayProvider`, shows `QuickCheckInWidget` at top when not logged, shows `DailyLogStatusBanner` when already logged
- `lib/features/logging/view/screens/create_entry_screen.dart` — added optional `prefill: QuickCheckInData?` param with initState pre-fill logic
- `lib/core/routing/app_router.dart` — `/logging/create` route reads `state.extra as QuickCheckInData?` and passes to screen (fully backward compatible)

Closes #495