### PR TITLE
feat: leaderboard route, OG tags, quick check-in, duplicate/share

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,26 @@
     <title>EchoMirror — Your mind, reflected back to you.</title>
     <meta name="description" content="Track moods, uncover emotional patterns, earn rewards. EchoMirror is the wellbeing companion powered by AI, built for humans." />
 
+    <!-- Open Graph -->
+    <meta property="og:type"        content="website" />
+    <meta property="og:title"       content="EchoMirror — Your mind, reflected back to you." />
+    <meta property="og:description" content="Track moods, decode patterns, earn rewards on Stellar. A wellbeing companion that listens as carefully as you listen to yourself." />
+    <meta property="og:url"         content="https://echomirrorbutler.vercel.app" />
+    <meta property="og:image"       content="https://echomirrorbutler.vercel.app/og-image.png" />
+    <meta property="og:image:width"  content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card"        content="summary_large_image" />
+    <meta name="twitter:title"       content="EchoMirror — Your mind, reflected back to you." />
+    <meta name="twitter:description" content="Track moods, decode patterns, earn rewards on Stellar." />
+    <meta name="twitter:image"       content="https://echomirrorbutler.vercel.app/og-image.png" />
+
+    <!-- Preconnect hints -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://wornmnmswuofodkjupfc.supabase.co" />
+
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/app-icon.png" />
 

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -40,6 +40,9 @@ const GlobalMirrorPage = lazy(() =>
 const SettingsPage = lazy(() =>
   import('../features/settings/settings-page').then((m) => ({ default: m.SettingsPage })),
 )
+const LeaderboardPage = lazy(() =>
+  import('../features/leaderboard/leaderboard-page').then((m) => ({ default: m.LeaderboardPage })),
+)
 const OnboardingPage = lazy(() =>
   import('../features/onboarding/onboarding-page').then((m) => ({ default: m.OnboardingPage })),
 )
@@ -263,6 +266,14 @@ export function AppRouter() {
             element={
               <RouteErrorBoundary routeName="Settings">
                 <SettingsPage />
+              </RouteErrorBoundary>
+            }
+          />
+          <Route
+            path="/leaderboard"
+            element={
+              <RouteErrorBoundary routeName="Leaderboard">
+                <LeaderboardPage />
               </RouteErrorBoundary>
             }
           />

--- a/frontend/src/features/dashboard/components/QuickCheckInWidget.tsx
+++ b/frontend/src/features/dashboard/components/QuickCheckInWidget.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { supabase } from '../../../lib/supabase'
+import { useAuth } from '../../../lib/auth-context'
+import { toDateInputValue } from '../../../lib/date'
+
+const MOOD_EMOJIS = ['😞', '😕', '😐', '🙂', '😄']
+const MOOD_LABELS = ['Very sad', 'Sad', 'Neutral', 'Happy', 'Very happy']
+const MAX_NOTE_LENGTH = 120
+
+function getTodayDate() {
+  return toDateInputValue(new Date())
+}
+
+export function QuickCheckInWidget() {
+  const { user } = useAuth()
+  const queryClient = useQueryClient()
+  const [selectedMood, setSelectedMood] = useState<number | null>(null)
+  const [note, setNote] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  // Check if today's log already exists
+  const todayLogQuery = useQuery({
+    queryKey: ['today-log', user?.id],
+    queryFn: async () => {
+      if (!user) return null
+      const today = getTodayDate()
+      const start = new Date(`${today}T00:00:00.000Z`).toISOString()
+      const end = new Date(`${today}T23:59:59.999Z`).toISOString()
+
+      const { data, error } = await supabase
+        .from('log_entries')
+        .select('id, mood, notes')
+        .eq('user_id', user.id)
+        .gte('date', start)
+        .lte('date', end)
+        .maybeSingle()
+
+      if (error) throw error
+      return data
+    },
+    enabled: !!user,
+    staleTime: 60_000, // 1 minute
+  })
+
+  const createLogMutation = useMutation({
+    mutationFn: async () => {
+      if (!user || selectedMood === null) throw new Error('Missing data')
+
+      const today = getTodayDate()
+      const { data, error } = await supabase
+        .from('log_entries')
+        .insert({
+          user_id: user.id,
+          date: new Date(`${today}T12:00:00.000Z`).toISOString(),
+          mood: selectedMood,
+          habits: [],
+          notes: note.trim() || null,
+        })
+        .select('id')
+        .single()
+
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      setSubmitted(true)
+      queryClient.invalidateQueries({ queryKey: ['today-log', user?.id] })
+      queryClient.invalidateQueries({ queryKey: ['logs', user?.id] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard-streak', user?.id] })
+    },
+  })
+
+  // Already logged today
+  if (todayLogQuery.data && !submitted) {
+    return (
+      <div className="quick-checkin-card quick-checkin-card--done">
+        <div className="quick-checkin-done">
+          <span className="quick-checkin-done-icon">✓</span>
+          <span>Logged today</span>
+        </div>
+        <Link to={`/logs/${todayLogQuery.data.id}`} className="quick-checkin-link">
+          View log →
+        </Link>
+      </div>
+    )
+  }
+
+  // Just submitted
+  if (submitted) {
+    return (
+      <div className="quick-checkin-card quick-checkin-card--success">
+        <div className="quick-checkin-success">
+          <span className="quick-checkin-success-icon">✓</span>
+          <span>Logged today — +1 ECHO earned 🎉</span>
+        </div>
+        <Link
+          to={`/logs/new?mood=${selectedMood}&notes=${encodeURIComponent(note)}`}
+          className="quick-checkin-link"
+        >
+          Add more detail →
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="quick-checkin-card">
+      <h3 className="quick-checkin-title">How are you feeling?</h3>
+
+      {/* Mood selector */}
+      <div role="radiogroup" aria-label="Mood selection" className="quick-checkin-moods">
+        {MOOD_EMOJIS.map((emoji, index) => (
+          <button
+            key={index}
+            role="radio"
+            aria-checked={selectedMood === index}
+            aria-label={`${MOOD_LABELS[index]}, mood ${index + 1}`}
+            onClick={() => setSelectedMood(index)}
+            onKeyDown={(e) => {
+              if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+                e.preventDefault()
+                setSelectedMood((prev) => (prev === null ? 0 : Math.min(prev + 1, 4)))
+              } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+                e.preventDefault()
+                setSelectedMood((prev) => (prev === null ? 4 : Math.max(prev - 1, 0)))
+              }
+            }}
+            className={`quick-checkin-mood-btn ${selectedMood === index ? 'quick-checkin-mood-btn--selected' : ''}`}
+          >
+            <span className="quick-checkin-mood-emoji">{emoji}</span>
+            <span className="quick-checkin-mood-label">{MOOD_LABELS[index]}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Optional note */}
+      <div className="quick-checkin-note">
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value.slice(0, MAX_NOTE_LENGTH))}
+          placeholder="One thing on your mind?"
+          maxLength={MAX_NOTE_LENGTH}
+          rows={2}
+          className="quick-checkin-textarea"
+          aria-label="Optional note"
+        />
+        <span className="quick-checkin-char-count">{note.length}/{MAX_NOTE_LENGTH}</span>
+      </div>
+
+      {/* Submit */}
+      <button
+        onClick={() => createLogMutation.mutate()}
+        disabled={selectedMood === null || createLogMutation.isPending}
+        className="quick-checkin-submit"
+      >
+        {createLogMutation.isPending ? 'Logging...' : 'Log it'}
+      </button>
+
+      {createLogMutation.isError && (
+        <p className="quick-checkin-error" role="alert">
+          Failed to log. Please try again.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/dashboard-page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../../lib/auth-context";
 import type { LogEntry, Insight } from "../../lib/types";
 import { formatDate, moodToEmoji } from "../../lib/date";
 import { HabitTrackerWidget } from "./components/habit-tracker-widget";
+import { QuickCheckInWidget } from "./components/QuickCheckInWidget";
 
 async function fetchMoodTrend(userId: string) {
   const today = new Date();
@@ -162,38 +163,10 @@ export function DashboardPage() {
 
   return (
     <section className="feature-grid">
-      {/* Log Today's Mood button */}
-      <article className="card full-width" style={{ gridColumn: '1 / -1', padding: '0.75rem 1rem' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '0.8rem' }}>
-          <div>
-            <strong style={{ fontSize: '1rem' }}>How are you feeling today?</strong>
-            <p className="muted" style={{ margin: '0.15rem 0 0', fontSize: '0.85rem' }}>
-              Log your mood to track your emotional journey
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={async () => {
-              const today = new Date().toISOString().slice(0, 10)
-              const { data } = await supabase
-                .from('log_entries')
-                .select('id')
-                .eq('user_id', user.id)
-                .gte('date', `${today}T00:00:00.000Z`)
-                .lte('date', `${today}T23:59:59.999Z`)
-                .maybeSingle()
-              if (data) {
-                navigate(`/logs/${data.id}/edit`)
-              } else {
-                navigate(`/logs/new?date=${today}`)
-              }
-            }}
-            style={{ whiteSpace: 'nowrap' }}
-          >
-            Log Today's Mood
-          </button>
-        </div>
-      </article>
+      {/* Quick Check-in Widget */}
+      <div style={{ gridColumn: '1 / -1' }}>
+        <QuickCheckInWidget />
+      </div>
 
       {/* Mood Summary Card - spans 2 columns */}
       <article className="card">

--- a/frontend/src/features/logs/log-detail-page.tsx
+++ b/frontend/src/features/logs/log-detail-page.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../lib/auth-context'
 import type { LogEntry } from '../../lib/types'
@@ -38,6 +39,7 @@ export function LogDetailPage() {
   const { user } = useAuth()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const [shareToast, setShareToast] = useState(false)
 
   const entryQuery = useQuery({
     queryKey: ['log-entry', id],
@@ -65,6 +67,42 @@ export function LogDetailPage() {
       navigate('/logs')
     },
   })
+
+  const handleDuplicate = () => {
+    if (!entry) return
+    const params = new URLSearchParams()
+    params.set('mood', String(entry.mood ?? ''))
+    if (entry.habits.length > 0) params.set('habits', entry.habits.join(','))
+    if (entry.notes) params.set('notes', entry.notes)
+    navigate(`/logs/new?${params.toString()}`)
+  }
+
+  const handleShare = async () => {
+    if (!entry) return
+    const emoji = moodToEmoji(entry.mood)
+    const text = `Mood: ${emoji} ${entry.mood}/5${entry.habits.length > 0 ? ` · Habits: ${entry.habits.join(', ')}` : ''}`
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: `My mood today: ${emoji}`,
+          text,
+          url: window.location.href,
+        })
+      } catch {
+        // User cancelled share
+      }
+    } else {
+      // Fallback: copy to clipboard
+      try {
+        await navigator.clipboard.writeText(`${text}\n${window.location.href}`)
+        setShareToast(true)
+        setTimeout(() => setShareToast(false), 2000)
+      } catch {
+        // Clipboard not available
+      }
+    }
+  }
 
   if (!user) return null
 
@@ -112,10 +150,16 @@ export function LogDetailPage() {
               day: 'numeric',
             }).format(new Date(entry.date))}
           </h2>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
             <Link to={`/logs/${id}/edit`}>
               <button type="button">Edit</button>
             </Link>
+            <button type="button" onClick={handleDuplicate}>
+              Duplicate
+            </button>
+            <button type="button" onClick={handleShare}>
+              {shareToast ? 'Copied!' : 'Share'}
+            </button>
             <button
               type="button"
               className="danger"


### PR DESCRIPTION
Fixes #514, Fixes #515, Fixes #516, Fixes #517

## What changed

### #514 — Add /leaderboard route
- Add lazy import for `LeaderboardPage` in `router.tsx`
- Add route inside `<RequireAuth>` block with `RouteErrorBoundary`

### #515 — Open Graph and Twitter Card meta tags
- Add OG tags: type, title, description, url, image (1200×630)
- Add Twitter Card tags: summary_large_image
- Add preconnect hints for Google Fonts and Supabase

### #516 — Quick mood check-in widget
- New `QuickCheckInWidget` with 5 mood emoji buttons
- Accessible: role=radiogroup, arrow key navigation
- Optional 120-char note textarea
- Shows success message with ECHO reward after submit

### #517 — Duplicate and share buttons
- Duplicate: navigates to /logs/new with pre-filled params
- Share: Web Share API on mobile, clipboard fallback on desktop

## How to test
- Navigate to `/leaderboard` — should render, not 404
- Share URL on Twitter — OG preview should appear
- Dashboard shows quick check-in when no log exists for today
- Log detail page has Duplicate and Share buttons