### PR TITLE
fix(router): add /leaderboard route for LeaderboardPage

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -40,6 +40,9 @@ const GlobalMirrorPage = lazy(() =>
 const SettingsPage = lazy(() =>
   import('../features/settings/settings-page').then((m) => ({ default: m.SettingsPage })),
 )
+const LeaderboardPage = lazy(() =>
+  import('../features/leaderboard/leaderboard-page').then((m) => ({ default: m.LeaderboardPage })),
+)
 const OnboardingPage = lazy(() =>
   import('../features/onboarding/onboarding-page').then((m) => ({ default: m.OnboardingPage })),
 )
@@ -263,6 +266,14 @@ export function AppRouter() {
             element={
               <RouteErrorBoundary routeName="Settings">
                 <SettingsPage />
+              </RouteErrorBoundary>
+            }
+          />
+          <Route
+            path="/leaderboard"
+            element={
+              <RouteErrorBoundary routeName="Leaderboard">
+                <LeaderboardPage />
               </RouteErrorBoundary>
             }
           />


### PR DESCRIPTION
Fixes #514

## What changed
- Add lazy import for `LeaderboardPage` in `router.tsx`
- Add `/leaderboard` route inside `<RequireAuth>` block with `RouteErrorBoundary`

## Why
The sidebar nav links to `/leaderboard` but no route was defined, causing a 404.

## How to test
- Click the 🏆 Leaderboard link in the sidebar
- Navigate directly to `/leaderboard`
- Verify the page renders correctly in light and dark mode