### PR TITLE
fix(web): add Open Graph, Twitter Card meta tags and preconnect hints

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,26 @@
     <title>EchoMirror — Your mind, reflected back to you.</title>
     <meta name="description" content="Track moods, uncover emotional patterns, earn rewards. EchoMirror is the wellbeing companion powered by AI, built for humans." />
 
+    <!-- Open Graph -->
+    <meta property="og:type"        content="website" />
+    <meta property="og:title"       content="EchoMirror — Your mind, reflected back to you." />
+    <meta property="og:description" content="Track moods, decode patterns, earn rewards on Stellar. A wellbeing companion that listens as carefully as you listen to yourself." />
+    <meta property="og:url"         content="https://echomirrorbutler.vercel.app" />
+    <meta property="og:image"       content="https://echomirrorbutler.vercel.app/og-image.png" />
+    <meta property="og:image:width"  content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card"        content="summary_large_image" />
+    <meta name="twitter:title"       content="EchoMirror — Your mind, reflected back to you." />
+    <meta name="twitter:description" content="Track moods, decode patterns, earn rewards on Stellar." />
+    <meta name="twitter:image"       content="https://echomirrorbutler.vercel.app/og-image.png" />
+
+    <!-- Preconnect hints -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://wornmnmswuofodkjupfc.supabase.co" />
+
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/app-icon.png" />
 


### PR DESCRIPTION
Fixes #515

## What changed
- Add Open Graph tags (type, title, description, url, image)
- Add Twitter Card tags (summary_large_image)
- Add preconnect hints for Google Fonts and Supabase

## Why
Without OG tags, links shared on Slack/Twitter/WhatsApp/Discord show no preview image or title.

## How to test
- Share `https://echomirrorbutler.vercel.app` on Twitter or Slack
- Verify OG preview shows title, description, and image
- Check Lighthouse SEO score reaches ≥ 90