### PR TITLE
feat(web): add duplicate and share buttons to log detail page

### DIFF
--- a/frontend/src/features/logs/log-detail-page.tsx
+++ b/frontend/src/features/logs/log-detail-page.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../lib/auth-context'
 import type { LogEntry } from '../../lib/types'
@@ -38,6 +39,7 @@ export function LogDetailPage() {
   const { user } = useAuth()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const [shareToast, setShareToast] = useState(false)
 
   const entryQuery = useQuery({
     queryKey: ['log-entry', id],
@@ -65,6 +67,41 @@ export function LogDetailPage() {
       navigate('/logs')
     },
   })
+
+  const handleDuplicate = () => {
+    if (!entry) return
+    const params = new URLSearchParams()
+    params.set('mood', String(entry.mood ?? ''))
+    if (entry.habits.length > 0) params.set('habits', entry.habits.join(','))
+    if (entry.notes) params.set('notes', entry.notes)
+    navigate(`/logs/new?${params.toString()}`)
+  }
+
+  const handleShare = async () => {
+    if (!entry) return
+    const emoji = moodToEmoji(entry.mood)
+    const text = `Mood: ${emoji} ${entry.mood}/5${entry.habits.length > 0 ? ` · Habits: ${entry.habits.join(', ')}` : ''}`
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: `My mood today: ${emoji}`,
+          text,
+          url: window.location.href,
+        })
+      } catch {
+        // User cancelled
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(`${text}\n${window.location.href}`)
+        setShareToast(true)
+        setTimeout(() => setShareToast(false), 2000)
+      } catch {
+        // Clipboard unavailable
+      }
+    }
+  }
 
   if (!user) return null
 
@@ -112,10 +149,16 @@ export function LogDetailPage() {
               day: 'numeric',
             }).format(new Date(entry.date))}
           </h2>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
             <Link to={`/logs/${id}/edit`}>
               <button type="button">Edit</button>
             </Link>
+            <button type="button" onClick={handleDuplicate}>
+              Duplicate
+            </button>
+            <button type="button" onClick={handleShare}>
+              {shareToast ? 'Copied!' : 'Share'}
+            </button>
             <button
               type="button"
               className="danger"


### PR DESCRIPTION
Fixes #517

## What changed
- **Duplicate** button: navigates to `/logs/new` with mood, habits, and notes pre-filled via query params
- **Share** button: uses `navigator.share()` on mobile, clipboard fallback on desktop with "Copied!" toast

## Why
Useful for recurring routines (duplicate) and sharing mood tracking with friends/accountability partners.

## How to test
- Open any log detail page
- Click "Duplicate" — should navigate to `/logs/new` with fields pre-filled (date defaults to today)
- Click "Share" — on mobile should open native share sheet; on desktop should copy text to clipboard