### PR TITLE
feat(flutter): add haptic feedback to mood selection and gift send (#566)

### DIFF
--- a/lib/core/utils/haptics.dart
+++ b/lib/core/utils/haptics.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class Haptics {
+  const Haptics._();
+
+  static Future<void> selection() => _run(HapticFeedback.selectionClick);
+
+  static Future<void> impactMedium() => _run(HapticFeedback.mediumImpact);
+
+  static Future<void> impactLight() => _run(HapticFeedback.lightImpact);
+
+  static Future<void> error() => _run(HapticFeedback.vibrate);
+
+  static Future<void> _run(Future<void> Function() action) async {
+    try {
+      await action();
+    } catch (error) {
+      debugPrint('Haptics unavailable: $error');
+    }
+  }
+}

--- a/lib/features/global_mirror/view/screens/gift_screen.dart
+++ b/lib/features/global_mirror/view/screens/gift_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/themes/app_theme.dart';
 import '../../../../core/utils/date_formatter.dart';
+import '../../../../core/utils/haptics.dart';
 import '../../../auth/viewmodel/providers/auth_provider.dart';
 import '../../data/models/gift_transaction_model.dart';
 import '../../viewmodel/providers/gift_provider.dart';
@@ -63,6 +64,7 @@ class _GiftScreenState extends ConsumerState<GiftScreen> {
   }
 
   Future<void> _handleSend() async {
+    Haptics.impactMedium();
     final currentBalance = ref.read(giftProvider).echoBalance;
 
     if (_selectedAmount <= 0) {

--- a/lib/features/logging/view/screens/create_entry_screen.dart
+++ b/lib/features/logging/view/screens/create_entry_screen.dart
@@ -5,6 +5,7 @@ import '../../../../core/themes/app_theme.dart';
 import '../../../../core/widgets/shimmer_loading.dart';
 import '../../../../core/utils/date_formatter.dart';
 import '../../../../core/utils/error_handler.dart';
+import '../../../../core/utils/haptics.dart';
 import '../../../auth/viewmodel/providers/auth_provider.dart';
 import '../../../auth/view/widgets/custom_button.dart';
 import '../../../ai/viewmodel/providers/ai_provider.dart';
@@ -102,7 +103,10 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
   }
 
   Future<void> _handleSubmit() async {
-    if (!_formKey.currentState!.validate()) return;
+    if (!_formKey.currentState!.validate()) {
+      Haptics.error();
+      return;
+    }
 
     final authState = ref.read(authProvider);
     if (!authState.isAuthenticated || authState.user == null) {
@@ -144,6 +148,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
 
       if (mounted) {
         if (success) {
+          Haptics.impactLight();
           ErrorHandler.showSuccess(context, 'Entry created successfully!');
 
           // Share mood anonymously if opted in.
@@ -374,6 +379,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                                 _selectedMood == moodValue;
                             return GestureDetector(
                               onTap: () {
+                                Haptics.selection();
                                 setState(() {
                                   _selectedMood = isSelected
                                       ? null


### PR DESCRIPTION
Closes #566

Adds tactile feedback across the core mood and gifting flows using `HapticFeedback` from `flutter/services.dart` — no new dependencies.

- New `Haptics` helper (`lib/core/utils/haptics.dart`) wraps every call in try/catch so devices without haptics degrade gracefully.
- Mood selection tap → `selectionClick()`
- Gift send button tap → `mediumImpact()`
- Successful log entry → `lightImpact()`
- Form validation error → `vibrate()`

Note: the mood input is a discrete 1–5 selector rather than a literal slider, so `selectionClick()` fires on each selection — the integer-notch behavior described in the issue.

### Verification
- `dart analyze` on all touched files → No issues found.