### PR TITLE
feat(web): add shareable mood streak card with PNG export (#567)

### DIFF
--- a/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/dashboard-page.tsx
@@ -7,6 +7,7 @@ import type { LogEntry, Insight } from "../../lib/types";
 import { formatDate, moodToEmoji } from "../../lib/date";
 import { HabitTrackerWidget } from "./components/habit-tracker-widget";
 import { QuickCheckInWidget } from "./components/QuickCheckInWidget";
+import { shareStreakCard } from "./streak-card-canvas";
 import { predictTomorrowMood, type AnalyticsLogEntry } from "../analytics/analytics-helpers";
 
 async function fetchMoodTrend(userId: string) {
@@ -160,6 +161,7 @@ export function DashboardPage() {
 
   const queryClient = useQueryClient();
   const [showFreezeModal, setShowFreezeModal] = useState(false);
+  const [isSharingStreak, setIsSharingStreak] = useState(false);
 
   const purchaseFreezeMutation = useMutation({
     mutationFn: async () => {
@@ -228,6 +230,18 @@ export function DashboardPage() {
   }
 
   const echoData = echoQuery.data ?? { balance: 0, earnedToday: 0 };
+
+  const handleShareStreak = async () => {
+    if (isSharingStreak || currentStreak <= 0) return;
+    setIsSharingStreak(true);
+    try {
+      await shareStreakCard({ streak: currentStreak });
+    } catch (error) {
+      console.error("Failed to share streak card", error);
+    } finally {
+      setIsSharingStreak(false);
+    }
+  };
 
   return (
     <section className="feature-grid">
@@ -309,24 +323,42 @@ export function DashboardPage() {
             <div className="streak-count">
               <p className="muted">Current streak</p>
               <h2 style={{ margin: "0.25rem 0 0" }}>🔥 {currentStreak}-day streak</h2>
-              {currentStreak >= 3 && !freezeQuery.data && echoQuery.data && (echoQuery.data as { balance: number; earnedToday: number }).balance >= 10 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", marginTop: "0.75rem" }}>
                 <button
                   type="button"
-                  onClick={() => setShowFreezeModal(true)}
+                  onClick={handleShareStreak}
+                  disabled={isSharingStreak}
                   style={{
-                    marginTop: "0.75rem",
-                    background: "none",
+                    background: "var(--brand)",
                     border: "1px solid var(--brand)",
-                    color: "var(--brand)",
+                    color: "#fff",
                     borderRadius: "8px",
                     padding: "0.35rem 0.75rem",
                     fontSize: "0.8rem",
-                    cursor: "pointer",
+                    cursor: isSharingStreak ? "default" : "pointer",
+                    opacity: isSharingStreak ? 0.7 : 1,
                   }}
                 >
-                  ❄️ Protect my streak (5 ECHO)
+                  {isSharingStreak ? "Preparing…" : "↗ Share streak"}
                 </button>
-              )}
+                {currentStreak >= 3 && !freezeQuery.data && echoQuery.data && (echoQuery.data as { balance: number; earnedToday: number }).balance >= 10 && (
+                  <button
+                    type="button"
+                    onClick={() => setShowFreezeModal(true)}
+                    style={{
+                      background: "none",
+                      border: "1px solid var(--brand)",
+                      color: "var(--brand)",
+                      borderRadius: "8px",
+                      padding: "0.35rem 0.75rem",
+                      fontSize: "0.8rem",
+                      cursor: "pointer",
+                    }}
+                  >
+                    ❄️ Protect my streak (5 ECHO)
+                  </button>
+                )}
+              </div>
             </div>
           ) : (
             <div className="streak-count">

--- a/frontend/src/features/dashboard/streak-card-canvas.ts
+++ b/frontend/src/features/dashboard/streak-card-canvas.ts
@@ -1,0 +1,133 @@
+export interface StreakCardOptions {
+  streak: number;
+  appName?: string;
+  tagline?: string;
+  url?: string;
+}
+
+export type ShareStreakResult = "shared" | "downloaded" | "cancelled";
+
+const CARD_SIZE = 1080;
+const DEFAULT_APP_NAME = "EchoMirror";
+const DEFAULT_TAGLINE = "Your mind, reflected back to you.";
+const DEFAULT_URL = "echomirrorbutler.vercel.app";
+
+export function drawStreakCard(
+  canvas: HTMLCanvasElement,
+  options: StreakCardOptions,
+): void {
+  const {
+    streak,
+    appName = DEFAULT_APP_NAME,
+    tagline = DEFAULT_TAGLINE,
+    url = DEFAULT_URL,
+  } = options;
+
+  canvas.width = CARD_SIZE;
+  canvas.height = CARD_SIZE;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Canvas 2D context is not available");
+  }
+
+  const background = ctx.createLinearGradient(0, 0, CARD_SIZE, CARD_SIZE);
+  background.addColorStop(0, "#0a0f24");
+  background.addColorStop(1, "#141d3d");
+  ctx.fillStyle = background;
+  ctx.fillRect(0, 0, CARD_SIZE, CARD_SIZE);
+
+  ctx.strokeStyle = "rgba(129, 140, 248, 0.35)";
+  ctx.lineWidth = 4;
+  ctx.strokeRect(48, 48, CARD_SIZE - 96, CARD_SIZE - 96);
+
+  const centerX = CARD_SIZE / 2;
+  ctx.textAlign = "center";
+
+  ctx.textBaseline = "middle";
+  ctx.fillStyle = "#818cf8";
+  ctx.font = "600 60px system-ui, -apple-system, Segoe UI, Roboto, sans-serif";
+  ctx.fillText(`✦ ${appName}`, centerX, 190);
+
+  ctx.fillStyle = "#f97316";
+  ctx.font = "160px system-ui, -apple-system, Segoe UI, Roboto, sans-serif";
+  ctx.fillText("\u{1F525}", centerX, 400);
+
+  ctx.fillStyle = "#ffffff";
+  ctx.font = "700 300px system-ui, -apple-system, Segoe UI, Roboto, sans-serif";
+  ctx.fillText(String(streak), centerX, 620);
+
+  ctx.fillStyle = "rgba(255, 255, 255, 0.92)";
+  ctx.font = "600 66px system-ui, -apple-system, Segoe UI, Roboto, sans-serif";
+  ctx.fillText(streak === 1 ? "DAY STREAK" : "DAY STREAK", centerX, 800);
+
+  ctx.fillStyle = "rgba(255, 255, 255, 0.7)";
+  ctx.font = "40px system-ui, -apple-system, Segoe UI, Roboto, sans-serif";
+  ctx.fillText(tagline, centerX, 900);
+
+  ctx.fillStyle = "rgba(129, 140, 248, 0.85)";
+  ctx.font = "600 38px system-ui, -apple-system, Segoe UI, Roboto, sans-serif";
+  ctx.fillText(url, centerX, 990);
+}
+
+export function createStreakCardBlob(
+  options: StreakCardOptions,
+): Promise<Blob> {
+  const canvas = document.createElement("canvas");
+  drawStreakCard(canvas, options);
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error("Could not export streak card image"));
+      }
+    }, "image/png");
+  });
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = objectUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(objectUrl);
+}
+
+export async function shareStreakCard(
+  options: StreakCardOptions,
+): Promise<ShareStreakResult> {
+  const blob = await createStreakCardBlob(options);
+  const filename = `echomirror-${options.streak}-day-streak.png`;
+  const file = new File([blob], filename, { type: "image/png" });
+
+  const shareData: ShareData = {
+    files: [file],
+    title: `${options.streak}-day streak on ${options.appName ?? DEFAULT_APP_NAME}`,
+    text: `I'm on a ${options.streak}-day mood-logging streak on ${
+      options.appName ?? DEFAULT_APP_NAME
+    }!`,
+  };
+
+  if (
+    typeof navigator.share === "function" &&
+    typeof navigator.canShare === "function" &&
+    navigator.canShare(shareData)
+  ) {
+    try {
+      await navigator.share(shareData);
+      return "shared";
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return "cancelled";
+      }
+    }
+  }
+
+  downloadBlob(blob, filename);
+  return "downloaded";
+}


### PR DESCRIPTION
Closes #567

Adds a **Share streak** button to the dashboard streak card.

- New `frontend/src/features/dashboard/streak-card-canvas.ts` renders a 1080×1080 Canvas card (dark navy gradient, `✦ EchoMirror` wordmark, 🔥 streak count, tagline, URL watermark) and exports a PNG blob.
- Shares via the Web Share API when file sharing is supported (mobile) and falls back to a download link on desktop. User-cancelled shares are handled and do not trigger a download.
- Button wired into `dashboard-page.tsx`, shown whenever the current streak is greater than 0.

### Verification
- `tsc --noEmit` clean for the new and changed files.
- Dashboard test suite: no regression (identical pass/fail vs. base).