### PR TITLE
a11y(flutter): add semantic labels to mood selector buttons

### DIFF
--- a/lib/features/logging/view/screens/create_entry_screen.dart
+++ b/lib/features/logging/view/screens/create_entry_screen.dart
@@ -372,38 +372,43 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                             final moodValue = index + 1;
                             final isSelected =
                                 _selectedMood == moodValue;
-                            return GestureDetector(
-                              onTap: () {
-                                setState(() {
-                                  _selectedMood = isSelected
-                                      ? null
-                                      : moodValue;
-                                });
-                              },
-                              child: Container(
-                                width: 56,
-                                height: 56,
-                                decoration: BoxDecoration(
-                                  color: isSelected
-                                      ? AppTheme.accentColor
-                                          .withValues(alpha: 0.2)
-                                      : theme.colorScheme.surface,
-                                  shape: BoxShape.circle,
-                                  border: Border.all(
+                            return Semantics(
+                              button: true,
+                              selected: isSelected,
+                              label: 'Mood $moodValue of 5',
+                              child: GestureDetector(
+                                onTap: () {
+                                  setState(() {
+                                    _selectedMood = isSelected
+                                        ? null
+                                        : moodValue;
+                                  });
+                                },
+                                child: Container(
+                                  width: 56,
+                                  height: 56,
+                                  decoration: BoxDecoration(
                                     color: isSelected
                                         ? AppTheme.accentColor
-                                        : theme.colorScheme.outline
-                                            .withValues(alpha: 0.3),
-                                    width: isSelected ? 2 : 1,
+                                            .withValues(alpha: 0.2)
+                                        : theme.colorScheme.surface,
+                                    shape: BoxShape.circle,
+                                    border: Border.all(
+                                      color: isSelected
+                                          ? AppTheme.accentColor
+                                          : theme.colorScheme.outline
+                                              .withValues(alpha: 0.3),
+                                      width: isSelected ? 2 : 1,
+                                    ),
                                   ),
-                                ),
-                                child: Icon(
-                                  _getMoodIcon(moodValue),
-                                  size: 28,
-                                  color: isSelected
-                                      ? AppTheme.accentColor
-                                      : theme.colorScheme.onSurface
-                                          .withValues(alpha: 0.6),
+                                  child: Icon(
+                                    _getMoodIcon(moodValue),
+                                    size: 28,
+                                    color: isSelected
+                                        ? AppTheme.accentColor
+                                        : theme.colorScheme.onSurface
+                                            .withValues(alpha: 0.6),
+                                  ),
                                 ),
                               ),
                             );


### PR DESCRIPTION
The 1–5 mood buttons on the log-entry screen were icon-only `GestureDetector`s with no accessibility semantics, so screen readers announced nothing and could not convey which mood was selected.

This wraps each button in a `Semantics` node exposing it as a button with a `Mood N of 5` label and its selected state — a small inclusivity win for a wellness app.

### Verification
- `dart analyze` → No issues found.