### PR TITLE
feat(backend): rate limit mood log creation to 10/user/hour

### DIFF
--- a/lib/features/logging/data/repositories/logging_repository.dart
+++ b/lib/features/logging/data/repositories/logging_repository.dart
@@ -1,7 +1,21 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../../../core/services/supabase_client_service.dart';
 import '../models/log_entry_model.dart';
+
+/// Thrown when the server-side mood log rate limit (max 10 logs per user per
+/// hour, enforced by a Postgres trigger on `log_entries`) is exceeded.
+class MoodLogRateLimitException implements Exception {
+  MoodLogRateLimitException(this.retryAfterSeconds);
+
+  final int retryAfterSeconds;
+
+  @override
+  String toString() =>
+      'rate_limit_exceeded: retry after $retryAfterSeconds seconds';
+}
 
 /// Repository for logging operations
 /// Handles all Supabase table queries for daily logging
@@ -30,6 +44,21 @@ class LoggingRepository {
     return '$year-$month-$day';
   }
 
+  /// Parses the `{"error":"rate_limit_exceeded","retry_after_seconds":N}`
+  /// payload the `enforce_mood_log_rate_limit` trigger sends as the
+  /// PostgrestException message, defaulting to 3600s if it can't be parsed.
+  int _parseRetryAfterSeconds(String message) {
+    try {
+      final decoded = jsonDecode(message);
+      if (decoded is Map && decoded['retry_after_seconds'] is int) {
+        return decoded['retry_after_seconds'] as int;
+      }
+    } catch (_) {
+      // Fall through to default below.
+    }
+    return 3600;
+  }
+
   /// Create a new log entry
   Future<LogEntryModel> createLogEntry(LogEntryModel entry) async {
     try {
@@ -48,6 +77,16 @@ class LoggingRepository {
 
       debugPrint('[LoggingRepository] createLogEntry success');
       return LogEntryModel.fromJson(result);
+    } on PostgrestException catch (e) {
+      if (e.code == 'PT429') {
+        final retryAfter = _parseRetryAfterSeconds(e.message);
+        debugPrint(
+          '[LoggingRepository] createLogEntry rate limited, retryAfterSeconds=$retryAfter',
+        );
+        throw MoodLogRateLimitException(retryAfter);
+      }
+      debugPrint('[LoggingRepository] createLogEntry error -> $e');
+      throw Exception('Failed to create log entry: ${e.toString()}');
     } catch (e, stackTrace) {
       debugPrint('[LoggingRepository] createLogEntry error -> $e');
       debugPrint(

--- a/supabase/manual_tests/test_mood_log_rate_limit.sql
+++ b/supabase/manual_tests/test_mood_log_rate_limit.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- SQL Test: enforce_mood_log_rate_limit() Trigger on log_entries
+--
+-- Run: psql $DATABASE_URL -f supabase/manual_tests/test_mood_log_rate_limit.sql
+--
+-- Safe to run on staging: wrapped in a ROLLBACK transaction.
+-- ============================================================
+
+BEGIN;
+
+-- 1. Setup mock user
+INSERT INTO auth.users (id, email)
+VALUES ('77777777-7777-7777-7777-777777777777'::uuid, 'user_rate_limit@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+-- 2. Insert 10 log entries — should all succeed (at the limit, not over it)
+DO $$
+DECLARE
+  i int;
+BEGIN
+  FOR i IN 1..10 LOOP
+    INSERT INTO public.log_entries (user_id, date, mood)
+    VALUES ('77777777-7777-7777-7777-777777777777'::uuid, now()::date, 3);
+  END LOOP;
+END;
+$$;
+
+DO $$
+DECLARE
+  v_count int;
+BEGIN
+  SELECT count(*) INTO v_count
+  FROM public.log_entries
+  WHERE user_id = '77777777-7777-7777-7777-777777777777'::uuid;
+
+  IF v_count = 10 THEN
+    RAISE NOTICE 'SUCCESS: 10 log entries created within limit. Count: %', v_count;
+  ELSE
+    RAISE EXCEPTION 'FAIL: Expected 10 log entries, got %', v_count;
+  END IF;
+END;
+$$;
+
+-- 3. The 11th insert within the same rolling hour must be rejected with PT429 (HTTP 429)
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.log_entries (user_id, date, mood)
+    VALUES ('77777777-7777-7777-7777-777777777777'::uuid, now()::date, 4);
+
+    RAISE EXCEPTION 'FAIL: 11th log entry should have been rate-limited but was inserted';
+  EXCEPTION
+    WHEN sqlstate 'PT429' THEN
+      RAISE NOTICE 'SUCCESS: 11th log entry correctly rate-limited: %', sqlerrm;
+  END;
+END;
+$$;
+
+-- Verify still only 10 rows persisted (the rejected insert did not land)
+DO $$
+DECLARE
+  v_count int;
+BEGIN
+  SELECT count(*) INTO v_count
+  FROM public.log_entries
+  WHERE user_id = '77777777-7777-7777-7777-777777777777'::uuid;
+
+  IF v_count = 10 THEN
+    RAISE NOTICE 'SUCCESS: rate-limited insert did not persist. Count: %', v_count;
+  ELSE
+    RAISE EXCEPTION 'FAIL: Expected 10 log entries after rejection, got %', v_count;
+  END IF;
+END;
+$$;
+
+-- Rollback mock data
+ROLLBACK;

--- a/supabase/migrations/20260719000000_mood_log_rate_limit.sql
+++ b/supabase/migrations/20260719000000_mood_log_rate_limit.sql
@@ -1,0 +1,44 @@
+-- Migration: Server-side rate limit on mood log creation (max 10 logs per user per hour)
+-- Issue #565
+--
+-- log_entries is inserted directly by the Flutter client (no server endpoint sits in
+-- front of it), so the only place a limit can be enforced without being bypassable by a
+-- modified client is a trigger on the table itself. Reuses the existing
+-- public.check_rate_limit() helper (added in 20260530120000_add_rate_limits_and_transfer_rpc.sql
+-- for send-echo) so all rate-limited actions in this project share one accounting table.
+
+create or replace function public.enforce_mood_log_rate_limit()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_allowed boolean;
+  v_retry_after_seconds int;
+begin
+  v_allowed := public.check_rate_limit(new.user_id, 'mood_log', 10, 1.0);
+
+  if not v_allowed then
+    v_retry_after_seconds := greatest(
+      1,
+      ceil(extract(epoch from (date_trunc('hour', now()) + interval '1 hour' - now())))::int
+    );
+
+    raise sqlstate 'PT429' using
+      message = json_build_object(
+        'error', 'rate_limit_exceeded',
+        'retry_after_seconds', v_retry_after_seconds
+      )::text,
+      detail = 'Maximum 10 mood log entries per user per hour exceeded',
+      hint = format('Retry after %s seconds', v_retry_after_seconds);
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_enforce_mood_log_rate_limit on public.log_entries;
+
+create trigger trg_enforce_mood_log_rate_limit
+  before insert on public.log_entries
+  for each row
+  execute function public.enforce_mood_log_rate_limit();

--- a/test/features/logging/logging_repository_test.dart
+++ b/test/features/logging/logging_repository_test.dart
@@ -156,6 +156,31 @@ void main() {
       expect(() => repository.createLogEntry(entry), throwsA(isA<Exception>()));
     });
 
+    test(
+      'createLogEntry throws MoodLogRateLimitException when the '
+      'enforce_mood_log_rate_limit trigger raises PT429',
+      () async {
+        final entry = buildEntry();
+        when(() => mockSupabase.from('log_entries')).thenThrow(
+          PostgrestException(
+            message: '{"error":"rate_limit_exceeded","retry_after_seconds":42}',
+            code: 'PT429',
+          ),
+        );
+
+        await expectLater(
+          () => repository.createLogEntry(entry),
+          throwsA(
+            isA<MoodLogRateLimitException>().having(
+              (e) => e.retryAfterSeconds,
+              'retryAfterSeconds',
+              42,
+            ),
+          ),
+        );
+      },
+    );
+
     test('updateLogEntry returns updated model on success', () async {
       final entry = buildEntry().copyWith(mood: 5, notes: 'updated');
       final fakeBuilder = FakePostgrestBuilder(buildLogJson(mood: 5));


### PR DESCRIPTION
## Summary
Closes #565.

Mood logs are created by `LoggingRepository.createLogEntry` inserting directly into the `log_entries` table from the Flutter client — there is no Serverpod (or any) server endpoint in front of it, so an app-layer-only check could be bypassed by a modified client. This enforces the limit where it can't be bypassed: a `BEFORE INSERT` trigger on `log_entries`.

- Adds `enforce_mood_log_rate_limit()` trigger function + trigger on `public.log_entries`, reusing the existing `public.rate_limits` table and `public.check_rate_limit(user_id, action, max_count, window_hours)` RPC (already used by `send-echo` for the same "10 per hour" pattern), keyed on action `'mood_log'`.
- On breach, raises Postgres error `PT429`, which PostgREST maps to an HTTP 429 response; the message body is `{"error":"rate_limit_exceeded","retry_after_seconds":N}` as requested in the issue.
- `LoggingRepository.createLogEntry` now catches `PostgrestException` with `code == 'PT429'`, parses `retry_after_seconds`, and rethrows a new `MoodLogRateLimitException` so callers (and future UI) can distinguish rate-limit errors from generic failures.
- Added a manual SQL test (`supabase/manual_tests/test_mood_log_rate_limit.sql`) following the existing convention in that folder: inserts 10 log entries (allowed), then asserts the 11th is rejected with `PT429` and doesn't persist.
- Added a unit test in `logging_repository_test.dart` asserting `createLogEntry` surfaces `MoodLogRateLimitException(retryAfterSeconds: 42)` when Supabase returns a `PT429` `PostgrestException`.

## Test plan
- [x] Reviewed `enforce_mood_log_rate_limit()` against the existing `check_rate_limit()` semantics (fixed-hour window, consistent with `send-echo`'s already-shipped rate limiting).
- [ ] Run `psql $DATABASE_URL -f supabase/manual_tests/test_mood_log_rate_limit.sql` against a Supabase branch/staging DB to confirm the trigger fires as expected.
- [ ] Run `flutter test test/features/logging/logging_repository_test.dart` (no Dart/Flutter SDK was available in the environment this was authored in, so this is unverified — please run in CI).