### PR TITLE
feat(web): add achievement badges page with milestone celebrations and ECHO rewards

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -44,6 +44,9 @@ const SettingsPage = lazy(() =>
 const LeaderboardPage = lazy(() =>
   import('../features/leaderboard/leaderboard-page').then((m) => ({ default: m.LeaderboardPage })),
 )
+const AchievementsPage = lazy(() =>
+  import('../features/achievements/achievements-page').then((m) => ({ default: m.AchievementsPage })),
+)
 const OnboardingPage = lazy(() =>
   import('../features/onboarding/onboarding-page').then((m) => ({ default: m.OnboardingPage })),
 )
@@ -283,6 +286,14 @@ export function AppRouter() {
             element={
               <RouteErrorBoundary routeName="Leaderboard">
                 <LeaderboardPage />
+              </RouteErrorBoundary>
+            }
+          />
+          <Route
+            path="/achievements"
+            element={
+              <RouteErrorBoundary routeName="Achievements">
+                <AchievementsPage />
               </RouteErrorBoundary>
             }
           />

--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -7,6 +7,8 @@ import { useSearchLogs } from '../../lib/use-search-logs'
 import { useTheme, type Theme } from '../../lib/use-theme'
 import { formatDate, moodToEmoji } from '../../lib/date'
 import { NotificationDrawer } from '../../features/notifications/notification-drawer'
+import { AchievementsWatcher } from '../../features/achievements/achievements-watcher'
+import { useUnlockedAchievements } from '../../features/achievements/use-achievements'
 import { useGlobalShortcut } from '../../hooks/use-global-shortcut'
 import { MoodLogModal } from '../mood-log-modal'
 
@@ -33,6 +35,7 @@ const navItems = [
   { icon: '📊', to: '/analytics', label: 'Analytics' },
   { icon: '🌍', to: '/global-mirror', label: 'Global Mirror' },
   { icon: '🏆', to: '/leaderboard', label: 'Leaderboard' }, 
+  { icon: '\u{1F3C5}', to: '/achievements', label: 'Achievements' },
   { icon: '💎', to: '/wallet', label: 'Wallet' },
   { icon: '⚙️', to: '/settings', label: 'Settings' },
 ];
@@ -94,6 +97,9 @@ export function AppShell() {
     enabled: Boolean(user?.id),
     staleTime: 5 * 60 * 1000,
   })
+
+  const unlockedAchievementsQuery = useUnlockedAchievements(user?.id)
+  const achievementCount = Object.keys(unlockedAchievementsQuery.data ?? {}).length
 
   const avatarText = useMemo(() => {
     const name = profileQuery.data?.display_name ?? user?.email ?? ''
@@ -158,6 +164,7 @@ export function AppShell() {
   return (
     <div className="shell-root" aria-keyshortcuts="k">
       <MoodLogModal isOpen={isMoodModalOpen} onClose={() => setIsMoodModalOpen(false)} />
+      <AchievementsWatcher />
       <aside
         className={[
           'shell-sidebar',
@@ -190,7 +197,11 @@ export function AppShell() {
               onClick={() => setIsMobileDrawerOpen(false)}
             >
               <span className="icon">{item.icon}</span>
-              <span className="label">{item.label}</span>
+              <span className="label">
+                {item.to === '/achievements' && achievementCount > 0
+                  ? `${item.label} (${achievementCount})`
+                  : item.label}
+              </span>
             </NavLink>
           ))}
         </nav>

--- a/frontend/src/features/achievements/achievements-page.tsx
+++ b/frontend/src/features/achievements/achievements-page.tsx
@@ -1,0 +1,144 @@
+import { useAuth } from '../../lib/auth-context'
+import { formatDate } from '../../lib/date'
+import { ACHIEVEMENTS, type AchievementDef } from './achievements'
+import { useUnlockedAchievements } from './use-achievements'
+
+function LockIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="4" y="11" width="16" height="10" rx="2" />
+      <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+    </svg>
+  )
+}
+
+function BadgeCard({
+  definition,
+  unlockedAt,
+}: {
+  definition: AchievementDef
+  unlockedAt: string | undefined
+}) {
+  const isUnlocked = Boolean(unlockedAt)
+
+  return (
+    <div
+      className="card"
+      role="listitem"
+      aria-label={`${definition.name}: ${isUnlocked ? 'unlocked' : 'locked'}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        gap: '0.6rem',
+        opacity: isUnlocked ? 1 : 0.6,
+      }}
+    >
+      <div
+        aria-hidden="true"
+        style={{
+          width: '56px',
+          height: '56px',
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: 700,
+          fontSize: '1.5rem',
+          color: '#fff',
+          background: isUnlocked
+            ? 'linear-gradient(135deg, #f5a623, #d34b32)'
+            : 'var(--muted)',
+          filter: isUnlocked ? 'none' : 'grayscale(1)',
+        }}
+      >
+        {isUnlocked ? definition.icon : <LockIcon />}
+      </div>
+
+      <div>
+        <h3 style={{ margin: 0, fontSize: '1rem' }}>{definition.name}</h3>
+        <p className="muted" style={{ margin: '0.25rem 0 0', fontSize: '0.85rem' }}>
+          {definition.description}
+        </p>
+      </div>
+
+      {definition.echoReward > 0 ? (
+        <span style={{ fontWeight: 600, fontSize: '0.85rem', color: 'var(--brand)' }}>
+          +{definition.echoReward} ECHO
+        </span>
+      ) : null}
+
+      {isUnlocked ? (
+        <span className="muted" style={{ fontSize: '0.8rem' }}>
+          Unlocked {formatDate(unlockedAt!)}
+        </span>
+      ) : (
+        <span className="muted" style={{ fontSize: '0.8rem', fontStyle: 'italic' }}>
+          {definition.hint}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export function AchievementsPage() {
+  const { user } = useAuth()
+  const unlockedQuery = useUnlockedAchievements(user?.id)
+
+  if (unlockedQuery.isLoading) {
+    return <div className="page-message">Loading achievements...</div>
+  }
+
+  if (unlockedQuery.isError) {
+    return (
+      <div className="page-wrap">
+        <p className="muted">Failed to load achievements.</p>
+        <button type="button" onClick={() => void unlockedQuery.refetch()}>
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  const unlocked = unlockedQuery.data ?? {}
+  const unlockedCount = ACHIEVEMENTS.filter((entry) => entry.id in unlocked).length
+
+  return (
+    <div className="page-wrap" style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      <div>
+        <h1 style={{ margin: 0 }}>Achievements</h1>
+        <p className="muted" style={{ margin: '0.25rem 0 0' }}>
+          {unlockedCount} of {ACHIEVEMENTS.length} unlocked. Milestone badges earn bonus ECHO.
+        </p>
+      </div>
+
+      <div
+        role="list"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+          gap: '1rem',
+        }}
+      >
+        {ACHIEVEMENTS.map((definition) => (
+          <BadgeCard
+            key={definition.id}
+            definition={definition}
+            unlockedAt={unlocked[definition.id]}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/achievements/achievements-watcher.tsx
+++ b/frontend/src/features/achievements/achievements-watcher.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAuth } from '../../lib/auth-context'
+import { ACHIEVEMENTS } from './achievements'
+import {
+  ACHIEVEMENT_UNLOCKED_EVENT,
+  useAchievementSync,
+  type AchievementUnlockedDetail,
+} from './use-achievements'
+
+function ConfettiBlast() {
+  return (
+    <div className="confetti-wrap" aria-hidden="true" style={{ zIndex: 10000 }}>
+      {Array.from({ length: 24 }).map((_, index) => (
+        <span key={index} style={{ ['--piece-delay' as string]: `${index * 35}ms` }} />
+      ))}
+    </div>
+  )
+}
+
+// Mounted once in AppShell: keeps achievement state in sync and shows a
+// celebration modal each time an achievement is unlocked for the first time.
+export function AchievementsWatcher() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [queue, setQueue] = useState<AchievementUnlockedDetail[]>([])
+
+  useAchievementSync()
+
+  useEffect(() => {
+    const onUnlocked = (event: Event) => {
+      const detail = (event as CustomEvent<AchievementUnlockedDetail>).detail
+      setQueue((prev) => [...prev, detail])
+      void queryClient.invalidateQueries({ queryKey: ['achievements', user?.id] })
+      void queryClient.invalidateQueries({ queryKey: ['wallet', user?.id] })
+      void queryClient.invalidateQueries({ queryKey: ['wallet-history', user?.id] })
+      void queryClient.invalidateQueries({ queryKey: ['dashboard-echo', user?.id] })
+    }
+
+    window.addEventListener(ACHIEVEMENT_UNLOCKED_EVENT, onUnlocked)
+    return () => window.removeEventListener(ACHIEVEMENT_UNLOCKED_EVENT, onUnlocked)
+  }, [queryClient, user?.id])
+
+  const current = queue[0]
+  const definition = current
+    ? ACHIEVEMENTS.find((entry) => entry.id === current.id)
+    : undefined
+
+  const dismiss = useCallback(() => {
+    setQueue((prev) => prev.slice(1))
+  }, [])
+
+  useEffect(() => {
+    if (!current) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') dismiss()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [current, dismiss])
+
+  if (!current || !definition) return null
+
+  return (
+    <>
+      <ConfettiBlast />
+      <div
+        className="modal-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="achievement-unlocked-title"
+        style={{ zIndex: 9999 }}
+        onClick={dismiss}
+      >
+        <div
+          className="modal-card"
+          style={{ textAlign: 'center', gap: '0.5rem' }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div
+            aria-hidden="true"
+            style={{
+              width: '64px',
+              height: '64px',
+              margin: '0 auto',
+              borderRadius: '50%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontWeight: 700,
+              fontSize: '1.75rem',
+              color: '#fff',
+              background: 'linear-gradient(135deg, #f5a623, #d34b32)',
+            }}
+          >
+            {definition.icon}
+          </div>
+          <h2 id="achievement-unlocked-title" style={{ margin: 0 }}>
+            {'\u{1F3C6} Achievement unlocked!'}
+          </h2>
+          <p style={{ margin: 0, fontWeight: 600 }}>{definition.name}</p>
+          <p className="muted" style={{ margin: 0 }}>
+            {definition.description}
+          </p>
+          {current.reward > 0 ? (
+            <p style={{ margin: 0, fontWeight: 700, color: 'var(--brand)' }}>
+              +{current.reward} ECHO
+            </p>
+          ) : null}
+          <div className="modal-actions" style={{ justifyContent: 'center' }}>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => {
+                dismiss()
+                navigate('/achievements')
+              }}
+            >
+              View achievements
+            </button>
+            <button type="button" onClick={dismiss}>
+              Nice!
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/features/achievements/achievements.test.ts
+++ b/frontend/src/features/achievements/achievements.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'vitest'
+import {
+  ACHIEVEMENTS,
+  currentLoggingStreak,
+  evaluateAchievements,
+  maxConsecutiveHabitDays,
+  type AchievementProgress,
+} from './achievements'
+
+const baseProgress: AchievementProgress = {
+  logCount: 0,
+  currentStreak: 0,
+  insightCount: 0,
+  giftsSent: 0,
+  maxHabitRun: 0,
+}
+
+describe('ACHIEVEMENTS', () => {
+  test('defines all 8 badges with unique ids', () => {
+    expect(ACHIEVEMENTS).toHaveLength(8)
+    expect(new Set(ACHIEVEMENTS.map((entry) => entry.id)).size).toBe(8)
+  })
+
+  test('streak milestones carry the specified ECHO rewards', () => {
+    const rewardById = Object.fromEntries(
+      ACHIEVEMENTS.map((entry) => [entry.id, entry.echoReward]),
+    )
+    expect(rewardById.week_warrior).toBe(10)
+    expect(rewardById.month_master).toBe(50)
+    expect(rewardById.century).toBe(200)
+  })
+})
+
+describe('evaluateAchievements', () => {
+  test('returns nothing for a brand new user', () => {
+    expect(evaluateAchievements(baseProgress)).toEqual([])
+  })
+
+  test('unlocks first_log after one entry', () => {
+    expect(evaluateAchievements({ ...baseProgress, logCount: 1 })).toEqual(['first_log'])
+  })
+
+  test('streak milestones unlock cumulatively', () => {
+    expect(evaluateAchievements({ ...baseProgress, logCount: 7, currentStreak: 7 })).toEqual([
+      'first_log',
+      'week_warrior',
+    ])
+    expect(
+      evaluateAchievements({ ...baseProgress, logCount: 100, currentStreak: 100 }),
+    ).toEqual(['first_log', 'week_warrior', 'month_master', 'century'])
+  })
+
+  test('insight, gift, and habit achievements come from their own counters', () => {
+    expect(
+      evaluateAchievements({ ...baseProgress, insightCount: 1, giftsSent: 2, maxHabitRun: 10 }),
+    ).toEqual(['insight_seeker', 'echo_gifter', 'habit_hero'])
+    expect(evaluateAchievements({ ...baseProgress, maxHabitRun: 9 })).toEqual([])
+  })
+})
+
+describe('currentLoggingStreak', () => {
+  const now = Date.UTC(2026, 0, 10, 15)
+  const day = (offset: number) =>
+    new Date(Date.UTC(2026, 0, 10 + offset, 12)).toISOString()
+
+  test('returns 0 with no logs', () => {
+    expect(currentLoggingStreak([], now)).toBe(0)
+  })
+
+  test('counts consecutive days ending today', () => {
+    expect(currentLoggingStreak([day(0), day(-1), day(-2)], now)).toBe(3)
+  })
+
+  test('still alive when the last log was yesterday', () => {
+    expect(currentLoggingStreak([day(-1), day(-2)], now)).toBe(2)
+  })
+
+  test('broken when the last log is older than yesterday', () => {
+    expect(currentLoggingStreak([day(-2), day(-3)], now)).toBe(0)
+  })
+
+  test('a gap ends the count', () => {
+    expect(currentLoggingStreak([day(0), day(-1), day(-3)], now)).toBe(2)
+  })
+
+  test('duplicate logs on one day count once', () => {
+    expect(currentLoggingStreak([day(0), day(0), day(-1)], now)).toBe(2)
+  })
+
+  test('ignores unparseable dates', () => {
+    expect(currentLoggingStreak(['not-a-date', day(0)], now)).toBe(1)
+  })
+})
+
+describe('maxConsecutiveHabitDays', () => {
+  const day = (offset: number) =>
+    new Date(Date.UTC(2026, 0, 1 + offset)).toISOString()
+
+  test('returns 0 with no habit data', () => {
+    expect(maxConsecutiveHabitDays([])).toBe(0)
+    expect(maxConsecutiveHabitDays([{ date: day(0), habits: [] }])).toBe(0)
+  })
+
+  test('counts consecutive days for the same habit', () => {
+    const rows = [0, 1, 2].map((offset) => ({ date: day(offset), habits: ['water'] }))
+    expect(maxConsecutiveHabitDays(rows)).toBe(3)
+  })
+
+  test('a gap resets the run', () => {
+    const rows = [0, 1, 3, 4, 5].map((offset) => ({ date: day(offset), habits: ['water'] }))
+    expect(maxConsecutiveHabitDays(rows)).toBe(3)
+  })
+
+  test('runs are tracked per habit, not across habits', () => {
+    const rows = [
+      { date: day(0), habits: ['water'] },
+      { date: day(1), habits: ['reading'] },
+      { date: day(2), habits: ['water'] },
+    ]
+    expect(maxConsecutiveHabitDays(rows)).toBe(1)
+  })
+
+  test('duplicate logs on the same day count once', () => {
+    const rows = [
+      { date: day(0), habits: ['water'] },
+      { date: day(0), habits: ['water'] },
+      { date: day(1), habits: ['water'] },
+    ]
+    expect(maxConsecutiveHabitDays(rows)).toBe(2)
+  })
+
+  test('ignores unparseable dates', () => {
+    expect(maxConsecutiveHabitDays([{ date: 'not-a-date', habits: ['water'] }])).toBe(0)
+  })
+})

--- a/frontend/src/features/achievements/achievements.ts
+++ b/frontend/src/features/achievements/achievements.ts
@@ -1,0 +1,170 @@
+export type AchievementId =
+  | 'first_log'
+  | 'week_warrior'
+  | 'month_master'
+  | 'century'
+  | 'insight_seeker'
+  | 'echo_gifter'
+  | 'habit_hero'
+  | 'global_citizen'
+
+export type AchievementDef = {
+  id: AchievementId
+  name: string
+  description: string
+  hint: string
+  icon: string
+  echoReward: number
+}
+
+export const HABIT_HERO_RUN = 10
+
+export const ACHIEVEMENTS: AchievementDef[] = [
+  {
+    id: 'first_log',
+    name: 'First Log',
+    description: 'Log your first mood entry',
+    hint: 'Log a mood to get started',
+    icon: '\u{1F331}',
+    echoReward: 0,
+  },
+  {
+    id: 'week_warrior',
+    name: 'Week Warrior',
+    description: '7-day logging streak',
+    hint: 'Log your mood 7 days in a row',
+    icon: '\u{1F525}',
+    echoReward: 10,
+  },
+  {
+    id: 'month_master',
+    name: 'Month Master',
+    description: '30-day logging streak',
+    hint: 'Log your mood 30 days in a row',
+    icon: '\u{1F31F}',
+    echoReward: 50,
+  },
+  {
+    id: 'century',
+    name: 'Century',
+    description: '100-day logging streak',
+    hint: 'Log your mood 100 days in a row',
+    icon: '\u{1F4AF}',
+    echoReward: 200,
+  },
+  {
+    id: 'insight_seeker',
+    name: 'Insight Seeker',
+    description: 'Generate your first AI insight',
+    hint: 'Visit AI Insights and generate one',
+    icon: '\u2728',
+    echoReward: 0,
+  },
+  {
+    id: 'echo_gifter',
+    name: 'ECHO Gifter',
+    description: 'Send ECHO to another user',
+    hint: 'Send a gift from your wallet',
+    icon: '\u{1F381}',
+    echoReward: 0,
+  },
+  {
+    id: 'habit_hero',
+    name: 'Habit Hero',
+    description: `Log the same habit ${HABIT_HERO_RUN} days in a row`,
+    hint: `Track one habit for ${HABIT_HERO_RUN} consecutive days`,
+    icon: '\u{1F4AA}',
+    echoReward: 0,
+  },
+  {
+    id: 'global_citizen',
+    name: 'Global Citizen',
+    description: 'Drop a pin on the Global Mirror',
+    hint: 'Share your mood on the world map',
+    icon: '\u{1F4CD}',
+    echoReward: 0,
+  },
+]
+
+export type AchievementProgress = {
+  logCount: number
+  currentStreak: number
+  insightCount: number
+  giftsSent: number
+  maxHabitRun: number
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+// Longest run of consecutive days on which the same habit was logged.
+// log_entries stores habits as a jsonb array of habit names per entry.
+export function maxConsecutiveHabitDays(
+  rows: { date: string; habits: string[] }[],
+): number {
+  const daysByHabit = new Map<string, Set<number>>()
+
+  for (const row of rows) {
+    const time = Date.parse(row.date)
+    if (Number.isNaN(time)) continue
+    const day = Math.floor(time / DAY_MS)
+    for (const habit of row.habits) {
+      let days = daysByHabit.get(habit)
+      if (!days) {
+        days = new Set()
+        daysByHabit.set(habit, days)
+      }
+      days.add(day)
+    }
+  }
+
+  let best = 0
+  for (const days of daysByHabit.values()) {
+    const sorted = [...days].sort((a, b) => a - b)
+    let run = 1
+    for (let i = 0; i < sorted.length; i += 1) {
+      if (i > 0 && sorted[i] === sorted[i - 1] + 1) {
+        run += 1
+      } else {
+        run = 1
+      }
+      if (run > best) best = run
+    }
+  }
+  return best
+}
+
+// Consecutive UTC days with at least one log, counting back from today
+// (or yesterday, so the streak survives until the current day is missed).
+// Computed from log_entries because the get_current_streak RPC reads
+// mood_logs, a table nothing in the app writes to.
+export function currentLoggingStreak(dates: string[], now = Date.now()): number {
+  const days = new Set<number>()
+  for (const date of dates) {
+    const time = Date.parse(date)
+    if (Number.isNaN(time)) continue
+    days.add(Math.floor(time / DAY_MS))
+  }
+
+  const today = Math.floor(now / DAY_MS)
+  let day = days.has(today) ? today : today - 1
+  let streak = 0
+  while (days.has(day)) {
+    streak += 1
+    day -= 1
+  }
+  return streak
+}
+
+// global_citizen is not derivable from queryable data (mood pins are
+// anonymous), so it is unlocked directly when the user drops a pin.
+export function evaluateAchievements(progress: AchievementProgress): AchievementId[] {
+  const earned: AchievementId[] = []
+  if (progress.logCount >= 1) earned.push('first_log')
+  if (progress.currentStreak >= 7) earned.push('week_warrior')
+  if (progress.currentStreak >= 30) earned.push('month_master')
+  if (progress.currentStreak >= 100) earned.push('century')
+  if (progress.insightCount >= 1) earned.push('insight_seeker')
+  if (progress.giftsSent >= 1) earned.push('echo_gifter')
+  if (progress.maxHabitRun >= HABIT_HERO_RUN) earned.push('habit_hero')
+  return earned
+}

--- a/frontend/src/features/achievements/use-achievements.ts
+++ b/frontend/src/features/achievements/use-achievements.ts
@@ -1,0 +1,135 @@
+import { useEffect, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../lib/auth-context'
+import {
+  ACHIEVEMENTS,
+  currentLoggingStreak,
+  evaluateAchievements,
+  maxConsecutiveHabitDays,
+  type AchievementId,
+  type AchievementProgress,
+} from './achievements'
+
+export const ACHIEVEMENT_UNLOCKED_EVENT = 'echomirror:achievement-unlocked'
+
+export type AchievementUnlockedDetail = {
+  id: AchievementId
+  reward: number
+}
+
+type UnlockResult = {
+  success?: boolean
+  newly_unlocked?: boolean
+  reward?: number
+}
+
+// Unlocks via the unlock_achievement RPC (which also credits the ECHO
+// bonus server side) and broadcasts an event on first unlock so the
+// celebration modal fires exactly once.
+export async function unlockAchievement(id: AchievementId): Promise<boolean> {
+  const { data, error } = await supabase.rpc('unlock_achievement', {
+    p_achievement_id: id,
+  })
+  if (error) return false
+
+  const result = data as UnlockResult | null
+  if (!result?.success || !result.newly_unlocked) return false
+
+  window.dispatchEvent(
+    new CustomEvent<AchievementUnlockedDetail>(ACHIEVEMENT_UNLOCKED_EVENT, {
+      detail: { id, reward: result.reward ?? 0 },
+    }),
+  )
+  return true
+}
+
+export type UnlockedMap = Partial<Record<AchievementId, string>>
+
+async function fetchUnlocked(userId: string): Promise<UnlockedMap> {
+  const { data, error } = await supabase
+    .from('user_achievements')
+    .select('achievement_id, unlocked_at')
+    .eq('user_id', userId)
+  if (error) throw error
+
+  const map: UnlockedMap = {}
+  for (const row of (data ?? []) as { achievement_id: AchievementId; unlocked_at: string }[]) {
+    map[row.achievement_id] = row.unlocked_at
+  }
+  return map
+}
+
+export function useUnlockedAchievements(userId: string | undefined) {
+  return useQuery({
+    queryKey: ['achievements', userId],
+    queryFn: () => fetchUnlocked(userId!),
+    enabled: Boolean(userId),
+  })
+}
+
+async function fetchProgress(userId: string): Promise<AchievementProgress> {
+  const [logsRes, insightsRes, giftsRes] = await Promise.all([
+    supabase.from('log_entries').select('date, habits').eq('user_id', userId),
+    supabase
+      .from('ai_insights')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId),
+    supabase
+      .from('gift_transactions')
+      .select('id', { count: 'exact', head: true })
+      .eq('sender_user_id', userId),
+  ])
+
+  const logs = (logsRes.data ?? []) as { date: string; habits: string[] | null }[]
+
+  return {
+    logCount: logs.length,
+    currentStreak: currentLoggingStreak(logs.map((log) => log.date)),
+    insightCount: insightsRes.count ?? 0,
+    giftsSent: giftsRes.count ?? 0,
+    maxHabitRun: maxConsecutiveHabitDays(
+      logs.map((log) => ({ date: log.date, habits: log.habits ?? [] })),
+    ),
+  }
+}
+
+// Re-checks progress after logs/actions (the log, insight, and gift
+// mutations invalidate 'achievement-progress') and unlocks anything newly
+// earned. Stops querying once every derivable achievement is unlocked.
+export function useAchievementSync() {
+  const { user } = useAuth()
+  const syncingRef = useRef(false)
+
+  const unlockedQuery = useUnlockedAchievements(user?.id)
+  const unlocked = unlockedQuery.data
+
+  const allDerivableUnlocked =
+    unlocked !== undefined &&
+    ACHIEVEMENTS.every(
+      (entry) => entry.id === 'global_citizen' || entry.id in unlocked,
+    )
+
+  const progressQuery = useQuery({
+    queryKey: ['achievement-progress', user?.id],
+    queryFn: () => fetchProgress(user!.id),
+    enabled: Boolean(user?.id) && unlocked !== undefined && !allDerivableUnlocked,
+  })
+
+  const progress = progressQuery.data
+
+  useEffect(() => {
+    if (!user?.id || !unlocked || !progress || syncingRef.current) return
+
+    const missing = evaluateAchievements(progress).filter((id) => !(id in unlocked))
+    if (missing.length === 0) return
+
+    syncingRef.current = true
+    void (async () => {
+      for (const id of missing) {
+        await unlockAchievement(id)
+      }
+      syncingRef.current = false
+    })()
+  }, [user?.id, unlocked, progress])
+}

--- a/frontend/src/features/dashboard/components/QuickCheckInWidget.tsx
+++ b/frontend/src/features/dashboard/components/QuickCheckInWidget.tsx
@@ -68,6 +68,7 @@ export function QuickCheckInWidget() {
       queryClient.invalidateQueries({ queryKey: ['today-log', user?.id] })
       queryClient.invalidateQueries({ queryKey: ['logs', user?.id] })
       queryClient.invalidateQueries({ queryKey: ['dashboard-streak', user?.id] })
+      queryClient.invalidateQueries({ queryKey: ['achievement-progress', user?.id] })
     },
   })
 

--- a/frontend/src/features/global-mirror/global-mirror-page.tsx
+++ b/frontend/src/features/global-mirror/global-mirror-page.tsx
@@ -26,6 +26,7 @@ import type { RealtimeChannel, REALTIME_SUBSCRIBE_STATES } from '@supabase/supab
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../lib/auth-context'
 import { MoodPinCommentsPanel } from '../../components/mood-pin-comments-panel'
+import { unlockAchievement } from '../achievements/use-achievements'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -701,6 +702,8 @@ export function GlobalMirrorPage() {
       async (pos) => {
         try {
           await insertPin(user.id, pos.coords.latitude, pos.coords.longitude, selectedSentiment)
+          // Pins are anonymous, so this achievement is unlocked at drop time.
+          void unlockAchievement('global_citizen')
           setGeoStatus('done')
           scheduleMapInvalidate()
           setTimeout(() => setGeoStatus('idle'), 2000)

--- a/frontend/src/features/insights/insights-page.tsx
+++ b/frontend/src/features/insights/insights-page.tsx
@@ -917,6 +917,7 @@ export function InsightsPage() {
       setExpandedInsightId(created.id)
       await queryClient.invalidateQueries({ queryKey: ['insight-history', user?.id] })
       await queryClient.invalidateQueries({ queryKey: ['insight-actions', user?.id] })
+      await queryClient.invalidateQueries({ queryKey: ['achievement-progress', user?.id] })
     },
   })
 

--- a/frontend/src/features/logs/components/log-entry-form.tsx
+++ b/frontend/src/features/logs/components/log-entry-form.tsx
@@ -193,6 +193,7 @@ export function LogEntryForm({ mode, id, initialDate, onSuccess, onCancel, onExi
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['logs', user?.id] }),
         queryClient.invalidateQueries({ queryKey: ['log-entry', id] }),
+        queryClient.invalidateQueries({ queryKey: ['achievement-progress', user?.id] }),
       ])
       showToast(mode === 'create' ? 'Mood logged! +1 ECHO earned 🎉' : 'Changes saved', 'success')
       if (onSuccess) onSuccess(mode)

--- a/frontend/src/features/wallet/wallet-page.tsx
+++ b/frontend/src/features/wallet/wallet-page.tsx
@@ -475,6 +475,7 @@ export function WalletPage() {
       showToast('ECHO sent!', 'success')
       await queryClient.invalidateQueries({ queryKey: ['wallet', user?.id] })
       await queryClient.invalidateQueries({ queryKey: ['wallet-history', user?.id] })
+      await queryClient.invalidateQueries({ queryKey: ['achievement-progress', user?.id] })
     },
     onError: (error: Error) => {
       showToast(error.message, 'error')

--- a/supabase/migrations/20260723000000_add_user_achievements.sql
+++ b/supabase/migrations/20260723000000_add_user_achievements.sql
@@ -1,0 +1,168 @@
+-- Issue #521: achievement badges with milestone celebrations and ECHO rewards
+
+CREATE TABLE IF NOT EXISTS public.user_achievements (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  achievement_id text NOT NULL,
+  unlocked_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, achievement_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_achievements_user
+  ON public.user_achievements(user_id);
+
+ALTER TABLE public.user_achievements ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  CREATE POLICY "users read own" ON public.user_achievements
+    FOR SELECT USING (auth.uid() = user_id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- No client INSERT policy: rows are written only by the unlock_achievement
+-- RPC below, which verifies the achievement was actually earned.
+
+-- Unlocks an achievement for the calling user and credits the milestone
+-- ECHO bonus in the same transaction. Each achievement is re-derived from
+-- server-side data before unlocking, so clients cannot claim badges or
+-- rewards they have not earned. Streaks and habit runs are computed from
+-- log_entries (the table all log flows write to; mood_logs is unwritten).
+-- global_citizen is the one exception: mood pins are anonymous, so it is
+-- client-attested, and it carries no ECHO reward.
+-- Returns whether this call performed the unlock, so the client can fire
+-- the celebration only on first unlock.
+CREATE OR REPLACE FUNCTION public.unlock_achievement(p_achievement_id text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_user_id uuid := auth.uid();
+    v_reward integer;
+    v_needed_streak integer := 0;
+    v_earned boolean := false;
+    v_inserted boolean := false;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Not authenticated'
+        );
+    END IF;
+
+    v_reward := CASE p_achievement_id
+        WHEN 'first_log' THEN 0
+        WHEN 'week_warrior' THEN 10
+        WHEN 'month_master' THEN 50
+        WHEN 'century' THEN 200
+        WHEN 'insight_seeker' THEN 0
+        WHEN 'echo_gifter' THEN 0
+        WHEN 'habit_hero' THEN 0
+        WHEN 'global_citizen' THEN 0
+        ELSE NULL
+    END;
+
+    IF v_reward IS NULL THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Unknown achievement'
+        );
+    END IF;
+
+    CASE p_achievement_id
+        WHEN 'first_log' THEN
+            v_earned := EXISTS (
+                SELECT 1 FROM public.log_entries WHERE user_id = v_user_id
+            );
+        WHEN 'week_warrior' THEN
+            v_needed_streak := 7;
+        WHEN 'month_master' THEN
+            v_needed_streak := 30;
+        WHEN 'century' THEN
+            v_needed_streak := 100;
+        WHEN 'insight_seeker' THEN
+            v_earned := EXISTS (
+                SELECT 1 FROM public.ai_insights WHERE user_id = v_user_id
+            );
+        WHEN 'echo_gifter' THEN
+            v_earned := EXISTS (
+                SELECT 1 FROM public.gift_transactions
+                WHERE sender_user_id = v_user_id
+            );
+        WHEN 'habit_hero' THEN
+            -- Longest run of consecutive days on which the same habit was
+            -- logged (gaps-and-islands over distinct habit/day pairs).
+            SELECT COALESCE(MAX(run_length), 0) >= 10 INTO v_earned
+            FROM (
+                SELECT count(*) AS run_length
+                FROM (
+                    SELECT habit,
+                           d - (row_number() OVER (PARTITION BY habit ORDER BY d))::int AS grp
+                    FROM (
+                        SELECT DISTINCT jsonb_array_elements_text(habits) AS habit,
+                                        date::date AS d
+                        FROM public.log_entries
+                        WHERE user_id = v_user_id
+                    ) days
+                ) grouped
+                GROUP BY habit, grp
+            ) runs;
+        WHEN 'global_citizen' THEN
+            v_earned := true;
+    END CASE;
+
+    IF v_needed_streak > 0 THEN
+        -- A current streak of N days implies a run of N consecutive log
+        -- days, so checking the longest run validates the claim without
+        -- rejecting streaks kept alive by freezes or timezone edges.
+        SELECT COALESCE(MAX(run_length), 0) >= v_needed_streak INTO v_earned
+        FROM (
+            SELECT count(*) AS run_length
+            FROM (
+                SELECT d - (row_number() OVER (ORDER BY d))::int AS grp
+                FROM (
+                    SELECT DISTINCT date::date AS d
+                    FROM public.log_entries
+                    WHERE user_id = v_user_id
+                ) days
+            ) grouped
+            GROUP BY grp
+        ) runs;
+    END IF;
+
+    IF NOT v_earned THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Achievement not earned'
+        );
+    END IF;
+
+    INSERT INTO public.user_achievements (user_id, achievement_id)
+    VALUES (v_user_id, p_achievement_id)
+    ON CONFLICT (user_id, achievement_id) DO NOTHING;
+
+    v_inserted := FOUND;
+
+    IF v_inserted AND v_reward > 0 THEN
+        INSERT INTO public.echo_rewards (user_id, amount, reason)
+        VALUES (v_user_id, v_reward, 'achievement_' || p_achievement_id);
+
+        -- Upsert: the wallet row is created lazily when the user links or
+        -- creates a Stellar wallet, so it may not exist yet.
+        INSERT INTO public.user_wallets (user_id, balance)
+        VALUES (v_user_id, v_reward)
+        ON CONFLICT (user_id) DO UPDATE
+        SET balance = user_wallets.balance + EXCLUDED.balance,
+            updated_at = now();
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'newly_unlocked', v_inserted,
+        'reward', CASE WHEN v_inserted THEN v_reward ELSE 0 END
+    );
+END;
+$$;


### PR DESCRIPTION
## What
Implements the achievement badges feature from #521: a user_achievements migration with the RLS policies from the issue, an /achievements page, milestone celebrations, and ECHO rewards.

## How
- The unlock_achievement RPC re-derives every claim from server-side data before granting, credits the milestone ECHO bonus in the same transaction, and is idempotent, so clients cannot mint badges or rewards and the celebration fires only on first unlock.
- Streaks and habit runs are computed from log_entries, the table the log flows actually write to (the get_current_streak RPC reads mood_logs, which nothing writes; noted in code).
- global_citizen unlocks at pin-drop time since mood pins are anonymous; it carries no ECHO reward.
- All 8 badges render in a locked/unlocked grid, the page is lazy-loaded behind auth, and the sidebar link shows the unlocked count. Celebrations reuse the existing confetti CSS.

## Testing
19/19 vitest on the new achievements module. tsc is clean on every touched file (the remaining errors are pre-existing in the untouched wallet-page.tsx). The migration follows the repo's existing migration idioms.

Closes #521
