### PR TITLE
feat(flutter): add offline mood log queue — cache entries locally and sync when connection restores

### DIFF
--- a/lib/core/models/local_models.dart
+++ b/lib/core/models/local_models.dart
@@ -1,35 +1,21 @@
 import 'package:hive_flutter/hive_flutter.dart';
 
-part 'local_models.g.dart';
-
-@HiveType(typeId: 0)
+/// A locally cached daily log entry. Entries created while offline are stored
+/// with `synced = false` and pushed to Supabase by [SyncService] when the
+/// connection is restored.
 class LocalLogEntry extends HiveObject {
-  @HiveField(0)
-  late String id;
+  String id;
+  String userId;
 
-  @HiveField(1)
-  late String userId;
-
-  @HiveField(2)
-  late String date;
-
-  @HiveField(3)
-  late int? mood;
-
-  @HiveField(4)
-  late List<String> habits;
-
-  @HiveField(5)
-  late String? notes;
-
-  @HiveField(6)
-  late DateTime createdAt;
-
-  @HiveField(7)
-  late DateTime updatedAt;
-
-  @HiveField(8)
-  late bool synced;
+  /// Date-only string in `YYYY-MM-DD` format (matches the `log_entries.date`
+  /// convention used by LoggingRepository).
+  String date;
+  int? mood;
+  List<String> habits;
+  String? notes;
+  DateTime createdAt;
+  DateTime updatedAt;
+  bool synced;
 
   LocalLogEntry({
     required this.id,
@@ -44,25 +30,13 @@ class LocalLogEntry extends HiveObject {
   });
 }
 
-@HiveType(typeId: 1)
 class LocalUserProfile extends HiveObject {
-  @HiveField(0)
-  late String userId;
-
-  @HiveField(1)
-  late String displayName;
-
-  @HiveField(2)
-  late String? avatarUrl;
-
-  @HiveField(3)
-  late String timezone;
-
-  @HiveField(4)
-  late int overallStreak;
-
-  @HiveField(5)
-  late DateTime lastUpdated;
+  String userId;
+  String displayName;
+  String? avatarUrl;
+  String timezone;
+  int overallStreak;
+  DateTime lastUpdated;
 
   LocalUserProfile({
     required this.userId,
@@ -74,25 +48,13 @@ class LocalUserProfile extends HiveObject {
   });
 }
 
-@HiveType(typeId: 2)
 class LocalDashboardSnapshot extends HiveObject {
-  @HiveField(0)
-  late String userId;
-
-  @HiveField(1)
-  late int totalLogs;
-
-  @HiveField(2)
-  late double averageMood;
-
-  @HiveField(3)
-  late int currentStreak;
-
-  @HiveField(4)
-  late List<String> topHabits;
-
-  @HiveField(5)
-  late DateTime cachedAt;
+  String userId;
+  int totalLogs;
+  double averageMood;
+  int currentStreak;
+  List<String> topHabits;
+  DateTime cachedAt;
 
   LocalDashboardSnapshot({
     required this.userId,
@@ -105,5 +67,136 @@ class LocalDashboardSnapshot extends HiveObject {
 
   bool isExpired() {
     return DateTime.now().difference(cachedAt).inHours > 24;
+  }
+}
+
+// Hand-written Hive adapters. The project does not run build_runner in CI,
+// so adapters are maintained manually. Field indexes must stay stable across
+// releases — append new fields with new indexes, never reuse old ones.
+
+class LocalLogEntryAdapter extends TypeAdapter<LocalLogEntry> {
+  @override
+  final int typeId = 0;
+
+  @override
+  LocalLogEntry read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return LocalLogEntry(
+      id: fields[0] as String,
+      userId: fields[1] as String,
+      date: fields[2] as String,
+      mood: fields[3] as int?,
+      habits: (fields[4] as List).cast<String>(),
+      notes: fields[5] as String?,
+      createdAt: fields[6] as DateTime,
+      updatedAt: fields[7] as DateTime,
+      synced: fields[8] as bool,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, LocalLogEntry obj) {
+    writer
+      ..writeByte(9)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.userId)
+      ..writeByte(2)
+      ..write(obj.date)
+      ..writeByte(3)
+      ..write(obj.mood)
+      ..writeByte(4)
+      ..write(obj.habits)
+      ..writeByte(5)
+      ..write(obj.notes)
+      ..writeByte(6)
+      ..write(obj.createdAt)
+      ..writeByte(7)
+      ..write(obj.updatedAt)
+      ..writeByte(8)
+      ..write(obj.synced);
+  }
+}
+
+class LocalUserProfileAdapter extends TypeAdapter<LocalUserProfile> {
+  @override
+  final int typeId = 1;
+
+  @override
+  LocalUserProfile read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return LocalUserProfile(
+      userId: fields[0] as String,
+      displayName: fields[1] as String,
+      avatarUrl: fields[2] as String?,
+      timezone: fields[3] as String,
+      overallStreak: fields[4] as int,
+      lastUpdated: fields[5] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, LocalUserProfile obj) {
+    writer
+      ..writeByte(6)
+      ..writeByte(0)
+      ..write(obj.userId)
+      ..writeByte(1)
+      ..write(obj.displayName)
+      ..writeByte(2)
+      ..write(obj.avatarUrl)
+      ..writeByte(3)
+      ..write(obj.timezone)
+      ..writeByte(4)
+      ..write(obj.overallStreak)
+      ..writeByte(5)
+      ..write(obj.lastUpdated);
+  }
+}
+
+class LocalDashboardSnapshotAdapter
+    extends TypeAdapter<LocalDashboardSnapshot> {
+  @override
+  final int typeId = 2;
+
+  @override
+  LocalDashboardSnapshot read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return LocalDashboardSnapshot(
+      userId: fields[0] as String,
+      totalLogs: fields[1] as int,
+      averageMood: fields[2] as double,
+      currentStreak: fields[3] as int,
+      topHabits: (fields[4] as List).cast<String>(),
+      cachedAt: fields[5] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, LocalDashboardSnapshot obj) {
+    writer
+      ..writeByte(6)
+      ..writeByte(0)
+      ..write(obj.userId)
+      ..writeByte(1)
+      ..write(obj.totalLogs)
+      ..writeByte(2)
+      ..write(obj.averageMood)
+      ..writeByte(3)
+      ..write(obj.currentStreak)
+      ..writeByte(4)
+      ..write(obj.topHabits)
+      ..writeByte(5)
+      ..write(obj.cachedAt);
   }
 }

--- a/lib/core/services/connectivity_service.dart
+++ b/lib/core/services/connectivity_service.dart
@@ -1,27 +1,35 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-part 'connectivity_service.g.dart';
+/// Thin wrapper around connectivity_plus exposing a simple online/offline
+/// view of the device's network state.
+class ConnectivityService {
+  ConnectivityService({Connectivity? connectivity})
+    : _connectivity = connectivity ?? Connectivity();
 
-@riverpod
-class ConnectivityService extends _$ConnectivityService {
-  late Connectivity _connectivity;
+  final Connectivity _connectivity;
 
-  @override
-  Stream<bool> build() {
-    _connectivity = Connectivity();
-    return _connectivity.onConnectivityChanged.map((result) {
-      return result != ConnectivityResult.none;
-    });
-  }
+  /// Emits `true` when the device gains connectivity and `false` when it is
+  /// lost. Consecutive duplicate states are filtered out, so listeners can
+  /// treat each `true` event as a reconnect.
+  Stream<bool> get onStatusChange =>
+      _connectivity.onConnectivityChanged.map(_hasConnection).distinct();
 
   Future<bool> isConnected() async {
-    final result = await _connectivity.checkConnectivity();
-    return result != ConnectivityResult.none;
+    return _hasConnection(await _connectivity.checkConnectivity());
+  }
+
+  static bool _hasConnection(List<ConnectivityResult> results) {
+    return results.any((result) => result != ConnectivityResult.none);
   }
 }
 
-@riverpod
-Stream<bool> isOnline(IsOnlineRef ref) {
-  return ref.watch(connectivityServiceProvider);
-}
+/// Connectivity service provider
+final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
+  return ConnectivityService();
+});
+
+/// Stream of the device's online status (true = online)
+final isOnlineProvider = StreamProvider<bool>((ref) {
+  return ref.watch(connectivityServiceProvider).onStatusChange;
+});

--- a/lib/core/services/mood_sync_service.dart
+++ b/lib/core/services/mood_sync_service.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/local_models.dart';
+import 'connectivity_service.dart';
+import 'offline_storage_service.dart';
+import 'sync_service.dart';
+
+/// Coordinates the offline mood log queue: queues entries while offline and
+/// auto-syncs them (oldest first) when connectivity is restored.
+///
+/// Pure service layer — exposes state via [pendingCount] /
+/// [watchPendingCount] and contains no UI logic.
+class MoodSyncService {
+  MoodSyncService({
+    required this.offlineStorage,
+    required this.syncService,
+    required this.connectivity,
+  });
+
+  final OfflineStorageService offlineStorage;
+  final SyncService syncService;
+  final ConnectivityService connectivity;
+
+  StreamSubscription<bool>? _connectivitySub;
+  bool _started = false;
+  bool _syncInProgress = false;
+  bool _syncRequestedWhileRunning = false;
+
+  /// Open local storage and begin watching connectivity. On every
+  /// offline→online transition (and once at startup if already online) any
+  /// queued entries are pushed to the server. Idempotent.
+  Future<void> start() async {
+    if (_started) return;
+    _started = true;
+
+    await offlineStorage.initialize();
+
+    _connectivitySub = connectivity.onStatusChange.listen((online) {
+      if (online) {
+        unawaited(syncPending());
+      }
+    });
+
+    if (await connectivity.isConnected()) {
+      unawaited(syncPending());
+    }
+  }
+
+  void dispose() {
+    _connectivitySub?.cancel();
+    _connectivitySub = null;
+    _started = false;
+  }
+
+  /// Queue a mood log locally for later sync.
+  ///
+  /// Re-logging a date that is already queued overwrites the queued entry.
+  /// Throws [OfflineQueueFullException] when the queue already holds
+  /// [OfflineStorageService.maxPendingLogEntries] entries.
+  Future<LocalLogEntry> queueMoodLog({
+    required String userId,
+    required DateTime date,
+    int? mood,
+    List<String> habits = const [],
+    String? notes,
+  }) async {
+    await offlineStorage.initialize();
+    final now = DateTime.now();
+    final entry = LocalLogEntry(
+      id: generateUuidV4(),
+      userId: userId,
+      date: dateKey(date),
+      mood: mood,
+      habits: List<String>.from(habits),
+      notes: notes,
+      createdAt: now,
+      updatedAt: now,
+    );
+    final queued = await offlineStorage.queueLogEntry(entry);
+    debugPrint(
+      '[MoodSyncService] queued mood log for ${queued.date} '
+      '(pending: $pendingCount)',
+    );
+    return queued;
+  }
+
+  /// Number of entries waiting to be synced (for the pending badge).
+  int get pendingCount => offlineStorage.pendingLogEntryCount;
+
+  /// Emits the pending count immediately and after every queue change.
+  Stream<int> watchPendingCount() => offlineStorage.watchPendingLogEntryCount();
+
+  /// Push queued entries to the server, oldest first. Concurrent calls are
+  /// coalesced: a call made while a run is in flight schedules one follow-up
+  /// run instead of racing it.
+  Future<SyncResult> syncPending() async {
+    if (_syncInProgress) {
+      _syncRequestedWhileRunning = true;
+      return const SyncResult();
+    }
+    _syncInProgress = true;
+    try {
+      var result = await syncService.syncPendingEntries();
+      while (_syncRequestedWhileRunning) {
+        _syncRequestedWhileRunning = false;
+        result = await syncService.syncPendingEntries();
+      }
+      if (result.syncedCount > 0 || result.failedCount > 0) {
+        debugPrint(
+          '[MoodSyncService] sync finished: ${result.syncedCount} synced, '
+          '${result.failedCount} failed'
+          '${result.rateLimited ? ' (rate limited)' : ''}',
+        );
+      }
+      return result;
+    } finally {
+      _syncInProgress = false;
+    }
+  }
+
+  /// Date-only key in `YYYY-MM-DD` (UTC), matching the `log_entries.date`
+  /// convention used by LoggingRepository.
+  static String dateKey(DateTime date) {
+    final utcDate = date.isUtc
+        ? date
+        : DateTime.utc(date.year, date.month, date.day);
+    final year = utcDate.year.toString().padLeft(4, '0');
+    final month = utcDate.month.toString().padLeft(2, '0');
+    final day = utcDate.day.toString().padLeft(2, '0');
+    return '$year-$month-$day';
+  }
+
+  /// RFC 4122 version 4 UUID. Hand-rolled to avoid a dependency on the
+  /// `uuid` package; entry ids must be valid UUIDs because `log_entries.id`
+  /// is a Postgres uuid column.
+  static String generateUuidV4({Random? random}) {
+    final rng = random ?? _random;
+    final bytes = List<int>.generate(16, (_) => rng.nextInt(256));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xx
+    final hex = bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+    return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-'
+        '${hex.substring(12, 16)}-${hex.substring(16, 20)}-'
+        '${hex.substring(20)}';
+  }
+
+  static final Random _random = Random.secure();
+}
+
+/// Mood sync service provider (kept alive for the app's lifetime so the
+/// connectivity subscription survives).
+final moodSyncServiceProvider = Provider<MoodSyncService>((ref) {
+  final service = MoodSyncService(
+    offlineStorage: ref.watch(offlineStorageServiceProvider),
+    syncService: ref.watch(syncServiceProvider),
+    connectivity: ref.watch(connectivityServiceProvider),
+  );
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+/// Starts the mood sync service (open storage + watch connectivity).
+/// Watched once from the app root, mirroring notificationInitProvider.
+final moodSyncInitProvider = FutureProvider<void>((ref) {
+  return ref.watch(moodSyncServiceProvider).start();
+});
+
+/// Pending (unsynced) mood log count, for the badge UI.
+final pendingMoodLogCountProvider = StreamProvider<int>((ref) {
+  return ref.watch(moodSyncServiceProvider).watchPendingCount();
+});

--- a/lib/core/services/offline_storage_service.dart
+++ b/lib/core/services/offline_storage_service.dart
@@ -1,34 +1,125 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../models/local_models.dart';
 
-part 'offline_storage_service.g.dart';
+/// Thrown when the offline mood log queue already holds
+/// [OfflineStorageService.maxPendingLogEntries] unsynced entries.
+class OfflineQueueFullException implements Exception {
+  const OfflineQueueFullException();
 
+  @override
+  String toString() =>
+      'Offline queue is full '
+      '(max ${OfflineStorageService.maxPendingLogEntries} pending entries)';
+}
+
+/// Local Hive-backed storage for offline support: the pending mood log queue,
+/// plus cached user profile and dashboard snapshots.
 class OfflineStorageService {
+  OfflineStorageService({Future<void> Function()? initializeHive})
+    : _initializeHive = initializeHive ?? Hive.initFlutter;
+
   static const String logEntriesBoxName = 'local_log_entries';
   static const String userProfileBoxName = 'local_user_profile';
   static const String dashboardBoxName = 'local_dashboard_snapshot';
+
+  /// Maximum number of unsynced log entries kept in the offline queue.
+  static const int maxPendingLogEntries = 50;
+
+  final Future<void> Function() _initializeHive;
 
   late Box<LocalLogEntry> _logEntriesBox;
   late Box<LocalUserProfile> _userProfileBox;
   late Box<LocalDashboardSnapshot> _dashboardBox;
 
-  Future<void> initialize() async {
+  Future<void>? _initFuture;
+  bool _initialized = false;
+
+  bool get isInitialized => _initialized;
+
+  /// Idempotent — safe to call from multiple providers; the first call wins
+  /// and later calls await the same future.
+  Future<void> initialize() {
+    return _initFuture ??= _doInitialize();
+  }
+
+  Future<void> _doInitialize() async {
+    await _initializeHive();
+    if (!Hive.isAdapterRegistered(0)) {
+      Hive.registerAdapter(LocalLogEntryAdapter());
+    }
+    if (!Hive.isAdapterRegistered(1)) {
+      Hive.registerAdapter(LocalUserProfileAdapter());
+    }
+    if (!Hive.isAdapterRegistered(2)) {
+      Hive.registerAdapter(LocalDashboardSnapshotAdapter());
+    }
     _logEntriesBox = await Hive.openBox<LocalLogEntry>(logEntriesBoxName);
     _userProfileBox = await Hive.openBox<LocalUserProfile>(userProfileBoxName);
-    _dashboardBox = await Hive.openBox<LocalDashboardSnapshot>(dashboardBoxName);
+    _dashboardBox = await Hive.openBox<LocalDashboardSnapshot>(
+      dashboardBoxName,
+    );
+    _initialized = true;
+  }
+
+  /// Queue a log entry for later sync.
+  ///
+  /// If a pending entry already exists for the same user and date it is
+  /// overwritten in place (one log per day, matching the server convention),
+  /// so re-logging the same day offline never consumes extra queue slots.
+  /// Throws [OfflineQueueFullException] when the queue holds
+  /// [maxPendingLogEntries] entries for other dates.
+  Future<LocalLogEntry> queueLogEntry(LocalLogEntry entry) async {
+    final existing = _findPendingByDate(entry.userId, entry.date);
+    if (existing != null) {
+      existing
+        ..mood = entry.mood
+        ..habits = entry.habits
+        ..notes = entry.notes
+        ..updatedAt = entry.updatedAt;
+      await existing.save();
+      return existing;
+    }
+    if (pendingLogEntryCount >= maxPendingLogEntries) {
+      throw const OfflineQueueFullException();
+    }
+    await _logEntriesBox.put(entry.id, entry);
+    return entry;
+  }
+
+  LocalLogEntry? _findPendingByDate(String userId, String date) {
+    for (final entry in _logEntriesBox.values) {
+      if (!entry.synced && entry.userId == userId && entry.date == date) {
+        return entry;
+      }
+    }
+    return null;
   }
 
   Future<void> saveLogEntry(LocalLogEntry entry) async {
     await _logEntriesBox.put(entry.id, entry);
   }
 
+  /// Unsynced entries, oldest first — the order they must be synced in.
   List<LocalLogEntry> getPendingLogEntries() {
-    return _logEntriesBox.values.where((e) => !e.synced).toList();
+    final pending = _logEntriesBox.values.where((e) => !e.synced).toList()
+      ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return pending;
   }
 
   List<LocalLogEntry> getAllLogEntries() {
     return _logEntriesBox.values.toList();
+  }
+
+  int get pendingLogEntryCount =>
+      _initialized ? _logEntriesBox.values.where((e) => !e.synced).length : 0;
+
+  /// Emits the current pending count immediately, then again after every
+  /// change to the queue box.
+  Stream<int> watchPendingLogEntryCount() async* {
+    await initialize();
+    yield pendingLogEntryCount;
+    yield* _logEntriesBox.watch().map((_) => pendingLogEntryCount);
   }
 
   Future<void> markEntrySynced(String entryId) async {
@@ -70,7 +161,7 @@ class OfflineStorageService {
   }
 }
 
-@riverpod
-OfflineStorageService offlineStorageService(OfflineStorageServiceRef ref) {
+/// Offline storage service provider
+final offlineStorageServiceProvider = Provider<OfflineStorageService>((ref) {
   return OfflineStorageService();
-}
+});

--- a/lib/core/services/sync_service.dart
+++ b/lib/core/services/sync_service.dart
@@ -1,35 +1,102 @@
-import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../models/local_models.dart';
 import 'offline_storage_service.dart';
 
-part 'sync_service.g.dart';
-
-class SyncService {
-  final OfflineStorageService offlineStorage;
-  final SupabaseClient supabase;
-
-  SyncService({
-    required this.offlineStorage,
-    required this.supabase,
+/// Outcome of a [SyncService.syncPendingEntries] run.
+class SyncResult {
+  const SyncResult({
+    this.syncedCount = 0,
+    this.failedCount = 0,
+    this.rateLimited = false,
   });
 
-  Future<bool> syncPendingEntries() async {
-    try {
-      final pendingEntries = offlineStorage.getPendingLogEntries();
-      if (pendingEntries.isEmpty) return true;
+  final int syncedCount;
+  final int failedCount;
 
-      for (final entry in pendingEntries) {
+  /// True when the run stopped early because the server-side mood log rate
+  /// limit (Postgres trigger on `log_entries`, error code PT429) was hit.
+  /// Remaining entries stay queued and are retried on the next run.
+  final bool rateLimited;
+
+  bool get allSynced => failedCount == 0 && !rateLimited;
+}
+
+/// Pushes locally queued log entries to Supabase.
+class SyncService {
+  SyncService({required this.offlineStorage, SupabaseClient? supabase})
+    : _injectedClient = supabase;
+
+  final OfflineStorageService offlineStorage;
+
+  /// Resolved lazily so constructing the service (e.g. from a provider in
+  /// tests) doesn't require an initialized Supabase singleton.
+  final SupabaseClient? _injectedClient;
+
+  SupabaseClient get supabase => _injectedClient ?? Supabase.instance.client;
+
+  /// Sync all pending entries, oldest first. Successfully synced entries are
+  /// removed from the local queue. A failed entry is kept for the next run;
+  /// failures don't block later entries unless the server rate limit is hit,
+  /// in which case the run stops early (further inserts would fail too).
+  Future<SyncResult> syncPendingEntries() async {
+    final pendingEntries = offlineStorage.getPendingLogEntries();
+    if (pendingEntries.isEmpty) return const SyncResult();
+
+    var synced = 0;
+    var failed = 0;
+    for (final entry in pendingEntries) {
+      try {
         await _syncLogEntry(entry);
-        await offlineStorage.markEntrySynced(entry.id);
+        await offlineStorage.deleteLogEntry(entry.id);
+        synced++;
+      } on PostgrestException catch (e) {
+        if (e.code == 'PT429') {
+          debugPrint('[SyncService] rate limited, stopping sync run');
+          return SyncResult(
+            syncedCount: synced,
+            failedCount: failed + (pendingEntries.length - synced - failed),
+            rateLimited: true,
+          );
+        }
+        debugPrint('[SyncService] failed to sync entry ${entry.id} -> $e');
+        failed++;
+      } catch (e) {
+        debugPrint('[SyncService] failed to sync entry ${entry.id} -> $e');
+        failed++;
       }
-      return true;
-    } catch (e) {
-      return false;
     }
+    return SyncResult(syncedCount: synced, failedCount: failed);
   }
 
+  /// Upload one entry, deduplicating against the server: if a row already
+  /// exists for this user and date (e.g. logged from another device, or a
+  /// previous sync run crashed after inserting), that row is updated instead
+  /// of inserting a duplicate. New rows are upserted under the entry's
+  /// client-generated UUID so retrying the same entry is idempotent.
   Future<void> _syncLogEntry(LocalLogEntry entry) async {
+    final existing = await supabase
+        .from('log_entries')
+        .select('id')
+        .eq('user_id', entry.userId)
+        .eq('date', entry.date)
+        .maybeSingle();
+
+    if (existing != null) {
+      await supabase
+          .from('log_entries')
+          .update({
+            'mood': entry.mood,
+            'habits': entry.habits,
+            'notes': entry.notes,
+            'updated_at': entry.updatedAt.toIso8601String(),
+          })
+          .eq('id', existing['id'] as String)
+          .eq('user_id', entry.userId);
+      return;
+    }
+
     await supabase.from('log_entries').upsert({
       'id': entry.id,
       'user_id': entry.userId,
@@ -53,12 +120,7 @@ class SyncService {
   }
 }
 
-@riverpod
-SyncService syncService(SyncServiceRef ref) {
-  final offlineStorage = ref.watch(offlineStorageServiceProvider);
-  final supabase = Supabase.instance.client;
-  return SyncService(
-    offlineStorage: offlineStorage,
-    supabase: supabase,
-  );
-}
+/// Sync service provider
+final syncServiceProvider = Provider<SyncService>((ref) {
+  return SyncService(offlineStorage: ref.watch(offlineStorageServiceProvider));
+});

--- a/lib/features/logging/view/screens/logging_screen.dart
+++ b/lib/features/logging/view/screens/logging_screen.dart
@@ -11,6 +11,7 @@ import '../../../auth/viewmodel/providers/auth_provider.dart';
 import '../../data/models/log_entry_model.dart';
 import '../../viewmodel/providers/logging_provider.dart';
 import '../widgets/logging_calendar.dart';
+import '../widgets/pending_sync_badge.dart';
 
 /// Daily logging screen
 class LoggingScreen extends ConsumerStatefulWidget {
@@ -44,6 +45,7 @@ class _LoggingScreenState extends ConsumerState<LoggingScreen> {
       appBar: AppBar(
         title: const Text('Daily Logging'),
         actions: [
+          const Center(child: PendingSyncBadge()),
           IconButton(
             icon: Icon(FontAwesomeIcons.calendar.data),
             onPressed: () {

--- a/lib/features/logging/view/widgets/pending_sync_badge.dart
+++ b/lib/features/logging/view/widgets/pending_sync_badge.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../core/services/mood_sync_service.dart';
+
+/// App bar badge showing how many mood logs are queued locally, waiting to
+/// be synced. Hidden entirely when the queue is empty.
+class PendingSyncBadge extends ConsumerWidget {
+  const PendingSyncBadge({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pendingCount = ref.watch(pendingMoodLogCountProvider).value ?? 0;
+    if (pendingCount <= 0) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Tooltip(
+        message:
+            '$pendingCount ${pendingCount == 1 ? 'entry' : 'entries'} '
+            'waiting to sync',
+        child: Badge.count(
+          count: pendingCount,
+          child: const Icon(Icons.cloud_upload_outlined),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/logging/viewmodel/providers/logging_provider.dart
+++ b/lib/features/logging/viewmodel/providers/logging_provider.dart
@@ -2,7 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/models/log_entry_model.dart';
 import '../../data/repositories/logging_repository.dart';
+import '../../../../core/services/connectivity_service.dart';
+import '../../../../core/services/mood_sync_service.dart';
 import '../../../../core/services/notification_service.dart';
+import '../../../../core/services/offline_storage_service.dart';
 
 /// Logging repository provider
 final loggingRepositoryProvider = Provider<LoggingRepository>((ref) {
@@ -11,11 +14,19 @@ final loggingRepositoryProvider = Provider<LoggingRepository>((ref) {
 
 /// Logging state notifier
 class LoggingNotifier extends StateNotifier<AsyncValue<List<LogEntryModel>>> {
-  LoggingNotifier(this._repository) : super(const AsyncValue.data([])) {
+  LoggingNotifier(
+    this._repository, {
+    MoodSyncService? moodSync,
+    ConnectivityService? connectivity,
+  }) : _moodSync = moodSync,
+       _connectivity = connectivity,
+       super(const AsyncValue.data([])) {
     // Don't load on init - wait for userId to be provided
   }
 
   final LoggingRepository _repository;
+  final MoodSyncService? _moodSync;
+  final ConnectivityService? _connectivity;
   String? _currentUserId;
   bool _hasLoaded = false;
 
@@ -51,32 +62,99 @@ class LoggingNotifier extends StateNotifier<AsyncValue<List<LogEntryModel>>> {
       _hasLoaded = true;
       state = AsyncValue.data(entries);
     } catch (e, stackTrace) {
-      debugPrint('[LoggingNotifier] âŒ Error loading log entries: $e');
+      debugPrint('[LoggingNotifier] âŒ Error loading log entries: $e');
       debugPrint('[LoggingNotifier] Stack trace: $stackTrace');
       _hasLoaded = false;
       state = AsyncValue.error(e, stackTrace);
     }
   }
 
-  /// Create a new log entry
+  /// Create a new log entry. When the device is offline (or the request
+  /// fails because connectivity dropped mid-flight), the entry is queued
+  /// locally and synced automatically once the connection is restored.
   Future<bool> createLogEntry(LogEntryModel entry) async {
+    if (_moodSync != null && !await _isOnline()) {
+      return _queueOffline(entry);
+    }
+
     try {
       final created = await _repository.createLogEntry(entry);
-      final currentData = state.value ?? [];
-      state = AsyncValue.data([...currentData, created]);
-
-      // Wrap notification call so platform plugin failures (e.g. MissingPluginException
-      // in unit tests) do not fail the entire log entry creation.
-      try {
-        await NotificationService().cancelNoLogTodayNotification();
-      } catch (_) {
-        // Ignore notification errors (e.g., in unit tests where plugins are unavailable)
-      }
-
+      _upsertIntoState(created);
+      await _cancelNoLogTodayNotification();
       return true;
+    } catch (e) {
+      // The request itself may have failed because we went offline
+      // mid-flight — queue instead of surfacing an error.
+      if (_moodSync != null && !await _isOnline()) {
+        return _queueOffline(entry);
+      }
+      state = AsyncValue.error(e, StackTrace.current);
+      return false;
+    }
+  }
+
+  Future<bool> _isOnline() async {
+    final connectivity = _connectivity;
+    if (connectivity == null) return true;
+    try {
+      return await connectivity.isConnected();
+    } catch (_) {
+      // If the connectivity check itself fails, assume online and let the
+      // network request decide.
+      return true;
+    }
+  }
+
+  Future<bool> _queueOffline(LogEntryModel entry) async {
+    final moodSync = _moodSync;
+    if (moodSync == null) return false;
+    try {
+      final queued = await moodSync.queueMoodLog(
+        userId: entry.userId,
+        date: entry.date,
+        mood: entry.mood,
+        habits: entry.habits,
+        notes: entry.notes,
+      );
+      debugPrint(
+        '[LoggingNotifier] Offline — queued entry for ${queued.date} '
+        '(pending: ${moodSync.pendingCount})',
+      );
+      // Reflect the queued entry in local state so calendar/list views show
+      // it immediately; it gets replaced by the server copy after sync.
+      _upsertIntoState(
+        entry.copyWith(id: queued.id, createdAt: queued.createdAt),
+      );
+      await _cancelNoLogTodayNotification();
+      return true;
+    } on OfflineQueueFullException catch (e, stackTrace) {
+      state = AsyncValue.error(e, stackTrace);
+      return false;
     } catch (e) {
       state = AsyncValue.error(e, StackTrace.current);
       return false;
+    }
+  }
+
+  /// Add [entry] to state, replacing an existing entry with the same id
+  /// (re-logging a queued day reuses the queued entry's id).
+  void _upsertIntoState(LogEntryModel entry) {
+    final currentData = state.value ?? [];
+    state = AsyncValue.data([
+      ...currentData.where((e) => e.id != entry.id),
+      entry,
+    ]);
+  }
+
+  Future<void> _cancelNoLogTodayNotification() async {
+    // Wrap notification call so platform plugin failures (e.g.
+    // MissingPluginException in unit tests) do not fail the entire log entry
+    // creation.
+    try {
+      await NotificationService().cancelNoLogTodayNotification();
+    } catch (_) {
+      // Ignore notification errors (e.g., in unit tests where plugins are
+      // unavailable)
     }
   }
 
@@ -132,5 +210,9 @@ final loggingProvider =
       ref,
     ) {
       final repository = ref.watch(loggingRepositoryProvider);
-      return LoggingNotifier(repository);
+      return LoggingNotifier(
+        repository,
+        moodSync: ref.watch(moodSyncServiceProvider),
+        connectivity: ref.watch(connectivityServiceProvider),
+      );
     });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,14 +6,18 @@ import 'core/viewmodel/providers/theme_provider.dart';
 import 'core/viewmodel/providers/notification_provider.dart';
 import 'core/services/supabase_client_service.dart';
 import 'core/services/deep_link_service.dart';
+import 'core/services/mood_sync_service.dart';
 import 'core/services/sentry_service.dart';
-import 'package:go_router/go_router.dart';
+import 'features/auth/viewmodel/providers/auth_provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Initialize Sentry before anything else so it captures bootstrap errors
-  const environment = String.fromEnvironment('APP_ENV', defaultValue: 'development');
+  const environment = String.fromEnvironment(
+    'APP_ENV',
+    defaultValue: 'development',
+  );
   await SentryService.init(environment: environment);
 
   // Initialize Supabase client service before app start.
@@ -38,7 +42,10 @@ class _EchoMirrorAppState extends ConsumerState<EchoMirrorApp> {
     // Initialize notifications on app start
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(notificationInitProvider.future);
-      
+
+      // Start the offline mood log queue (auto-syncs on reconnect)
+      ref.read(moodSyncInitProvider.future);
+
       // Initialize deep link handling
       final router = ref.read(routerProvider);
       _deepLinkService.initialize(
@@ -48,7 +55,7 @@ class _EchoMirrorAppState extends ConsumerState<EchoMirrorApp> {
       );
 
       // Set Sentry user ID if available
-      final user = ref.read(authStateProvider);
+      final user = ref.read(authProvider).user;
       if (user != null) {
         SentryService.setUserId(user.id);
       }

--- a/test/core/services/mood_sync_service_test.dart
+++ b/test/core/services/mood_sync_service_test.dart
@@ -1,0 +1,270 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:echomirror/core/models/local_models.dart';
+import 'package:echomirror/core/services/connectivity_service.dart';
+import 'package:echomirror/core/services/mood_sync_service.dart';
+import 'package:echomirror/core/services/offline_storage_service.dart';
+import 'package:echomirror/core/services/sync_service.dart';
+
+/// Records sync runs and drains the queue without touching the network.
+class _FakeSyncService extends SyncService {
+  _FakeSyncService(OfflineStorageService storage)
+    : super(
+        offlineStorage: storage,
+        supabase: SupabaseClient('http://localhost:54321', 'test-anon-key'),
+      );
+
+  int syncCalls = 0;
+  final List<List<String>> syncedDateBatches = [];
+
+  @override
+  Future<SyncResult> syncPendingEntries() async {
+    syncCalls++;
+    final pending = offlineStorage.getPendingLogEntries();
+    syncedDateBatches.add(pending.map((e) => e.date).toList());
+    for (final entry in pending) {
+      await offlineStorage.deleteLogEntry(entry.id);
+    }
+    return SyncResult(syncedCount: pending.length);
+  }
+}
+
+class _FakeConnectivityService extends ConnectivityService {
+  final StreamController<bool> controller = StreamController<bool>.broadcast();
+  bool online = false;
+
+  @override
+  Stream<bool> get onStatusChange => controller.stream;
+
+  @override
+  Future<bool> isConnected() async => online;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late OfflineStorageService storage;
+  late _FakeSyncService syncService;
+  late _FakeConnectivityService connectivity;
+  late MoodSyncService moodSync;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('mood_sync_test');
+    storage = OfflineStorageService(
+      initializeHive: () async => Hive.init(tempDir.path),
+    );
+    syncService = _FakeSyncService(storage);
+    connectivity = _FakeConnectivityService();
+    moodSync = MoodSyncService(
+      offlineStorage: storage,
+      syncService: syncService,
+      connectivity: connectivity,
+    );
+  });
+
+  tearDown(() async {
+    moodSync.dispose();
+    await connectivity.controller.close();
+    await Hive.deleteFromDisk();
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  LocalLogEntry buildEntry(String id, String date, DateTime createdAt) {
+    return LocalLogEntry(
+      id: id,
+      userId: 'user-1',
+      date: date,
+      mood: 3,
+      habits: const [],
+      createdAt: createdAt,
+      updatedAt: createdAt,
+    );
+  }
+
+  group('queueMoodLog', () {
+    test('stores a pending entry and increments pendingCount', () async {
+      expect(moodSync.pendingCount, 0);
+
+      final entry = await moodSync.queueMoodLog(
+        userId: 'user-1',
+        date: DateTime.utc(2026, 7, 26),
+        mood: 4,
+        habits: const ['walk'],
+        notes: 'offline note',
+      );
+
+      expect(moodSync.pendingCount, 1);
+      expect(entry.date, '2026-07-26');
+      expect(entry.synced, isFalse);
+      // Must be a valid v4 UUID (log_entries.id is a Postgres uuid column)
+      expect(
+        RegExp(
+          r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+        ).hasMatch(entry.id),
+        isTrue,
+      );
+    });
+
+    test('re-logging the same date overwrites the queued entry', () async {
+      await moodSync.queueMoodLog(
+        userId: 'user-1',
+        date: DateTime.utc(2026, 7, 26),
+        mood: 2,
+      );
+      final updated = await moodSync.queueMoodLog(
+        userId: 'user-1',
+        date: DateTime.utc(2026, 7, 26),
+        mood: 5,
+        notes: 'better now',
+      );
+
+      expect(moodSync.pendingCount, 1);
+      expect(updated.mood, 5);
+      expect(updated.notes, 'better now');
+    });
+
+    test('throws OfflineQueueFullException beyond 50 entries', () async {
+      await storage.initialize();
+      final firstDate = DateTime.utc(2026, 1, 1);
+      for (var i = 0; i < OfflineStorageService.maxPendingLogEntries; i++) {
+        await storage.queueLogEntry(
+          buildEntry(
+            'id-$i',
+            MoodSyncService.dateKey(firstDate.add(Duration(days: i))),
+            DateTime.now(),
+          ),
+        );
+      }
+      expect(moodSync.pendingCount, 50);
+
+      await expectLater(
+        () => moodSync.queueMoodLog(
+          userId: 'user-1',
+          date: DateTime.utc(2026, 7, 26),
+          mood: 3,
+        ),
+        throwsA(isA<OfflineQueueFullException>()),
+      );
+    });
+  });
+
+  group('pending queue ordering', () {
+    test('getPendingLogEntries returns oldest first', () async {
+      await storage.initialize();
+      final now = DateTime(2026, 7, 26, 12);
+      await storage.queueLogEntry(buildEntry('newest', '2026-07-26', now));
+      await storage.queueLogEntry(
+        buildEntry(
+          'oldest',
+          '2026-07-24',
+          now.subtract(const Duration(days: 2)),
+        ),
+      );
+      await storage.queueLogEntry(
+        buildEntry(
+          'middle',
+          '2026-07-25',
+          now.subtract(const Duration(days: 1)),
+        ),
+      );
+
+      final pending = storage.getPendingLogEntries();
+      expect(pending.map((e) => e.id).toList(), ['oldest', 'middle', 'newest']);
+    });
+  });
+
+  group('auto-sync on reconnect', () {
+    test(
+      'syncs queued entries oldest first when connection restores',
+      () async {
+        await moodSync.start();
+        expect(syncService.syncCalls, 0);
+
+        await moodSync.queueMoodLog(
+          userId: 'user-1',
+          date: DateTime.utc(2026, 7, 25),
+          mood: 2,
+        );
+        await moodSync.queueMoodLog(
+          userId: 'user-1',
+          date: DateTime.utc(2026, 7, 26),
+          mood: 4,
+        );
+        expect(moodSync.pendingCount, 2);
+
+        connectivity.online = true;
+        connectivity.controller.add(true);
+        await pumpEventQueue();
+
+        expect(syncService.syncCalls, 1);
+        expect(syncService.syncedDateBatches.single, [
+          '2026-07-25',
+          '2026-07-26',
+        ]);
+        expect(moodSync.pendingCount, 0);
+      },
+    );
+
+    test('syncs at startup when already online with pending entries', () async {
+      await moodSync.queueMoodLog(
+        userId: 'user-1',
+        date: DateTime.utc(2026, 7, 26),
+        mood: 3,
+      );
+
+      connectivity.online = true;
+      await moodSync.start();
+      await pumpEventQueue();
+
+      expect(syncService.syncCalls, 1);
+      expect(moodSync.pendingCount, 0);
+    });
+
+    test('does not sync while still offline', () async {
+      await moodSync.start();
+      await moodSync.queueMoodLog(
+        userId: 'user-1',
+        date: DateTime.utc(2026, 7, 26),
+        mood: 3,
+      );
+
+      connectivity.controller.add(false);
+      await pumpEventQueue();
+
+      expect(syncService.syncCalls, 0);
+      expect(moodSync.pendingCount, 1);
+    });
+  });
+
+  group('watchPendingCount', () {
+    test(
+      'emits current count immediately and updates on queue changes',
+      () async {
+        await storage.initialize();
+        final emissions = <int>[];
+        final sub = moodSync.watchPendingCount().listen(emissions.add);
+        await pumpEventQueue();
+        expect(emissions, [0]);
+
+        await moodSync.queueMoodLog(
+          userId: 'user-1',
+          date: DateTime.utc(2026, 7, 26),
+          mood: 3,
+        );
+        await pumpEventQueue();
+        expect(emissions.last, 1);
+
+        await sub.cancel();
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #569

## Summary of changes

Mood logs silently failed when the device was offline. The offline stack existed (`offline_storage_service.dart`, `connectivity_service.dart`, `sync_service.dart`) but was dead code: nothing initialized or imported it, its `part '*.g.dart'` directives pointed at files that were never generated (CI doesn't run build_runner), and it used the connectivity_plus v5 API against the v6 dependency. This PR rewires the whole stack in the manual-provider style used across the codebase and adds a new `MoodSyncService` that coordinates it.

- **`OfflineStorageService`** — self-initializing Hive boxes with hand-written type adapters (no codegen needed), pending queue **capped at 50 entries** (`OfflineQueueFullException` when full), re-logging an already-queued date overwrites in place instead of consuming a slot, oldest-first pending list, and a pending-count stream for the badge.
- **`SyncService`** — syncs **oldest first**, removes entries from the queue on success, and **deduplicates server-side**: if a `log_entries` row already exists for that user+date it updates it; otherwise it upserts under the entry's client-generated UUID so crash-retries are idempotent. Stops early when the server's 10-logs/hour rate-limit trigger fires (PT429) and leaves the rest queued.
- **`MoodSyncService` (new, no UI logic)** — watches connectivity and auto-syncs on every offline→online transition plus once at startup; coalesces concurrent sync runs; exposes `pendingCount` / `watchPendingCount()`; generates RFC-4122 v4 UUIDs (no `uuid` package dependency) since `log_entries.id` is a Postgres uuid.
- **`ConnectivityService`** — ported to the connectivity_plus v6 list-based API with a `distinct()` online/offline stream.
- **`LoggingNotifier.createLogEntry`** — checks connectivity first and queues when offline; if the request fails mid-flight it re-checks and queues instead of surfacing an error. Queued entries appear in local state immediately. A full queue surfaces as an error rather than silently dropping the log.
- **Pending count badge** — `PendingSyncBadge` in the Daily Logging app bar, hidden when the queue is empty.
- **Bootstrap** — `moodSyncInitProvider` started from `main.dart` (mirrors `notificationInitProvider`).
- **Drive-by fix** — `main.dart` referenced `authStateProvider`, which doesn't exist anywhere (pre-existing compile break); replaced with `ref.read(authProvider).user` and removed the unused `go_router` import it was masking.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Migration
- [ ] Documentation

## Checklist
- [x] `flutter analyze` passes (no issues in any changed file)
- [x] `dart format` run on changed files
- [x] No scratch/debug files committed
- [x] Closes linked issue (`Closes #569`)

## Screenshots (for UI changes)

UI change is a single app-bar badge (cloud icon + count) on the Daily Logging screen, only visible while entries are queued. _Screenshot to be added — no simulator available on the dev machine used for this PR._

## Testing done

- New suite `test/core/services/mood_sync_service_test.dart` (8 tests, all passing): queue + pending count, same-date overwrite, `OfflineQueueFullException` beyond 50 entries, oldest-first ordering, auto-sync on reconnect (oldest first, queue drained), sync at startup when already online, no sync while offline, pending-count stream emissions, and UUID v4 format validation.
- All 16 existing `logging_provider_test.dart` tests pass, including provider construction via `ProviderContainer` (the Supabase client is now resolved lazily so building the provider graph doesn't require an initialized Supabase singleton).
- Ran the logging + dashboard suites against this branch and against `development` with the same toolchain: **zero new failures introduced** (existing failures on both runs are pre-existing toolchain skew, unrelated to this change).

## Acceptance criteria

- [x] Mood logs created offline are cached locally instead of silently failing
- [x] Queued logs auto-sync when connection restores, oldest first
- [x] Pending count badge shown while entries await sync
- [x] Duplicates prevented server-side (existing user+date row updated; retries idempotent via client UUID)
- [x] Queue capped at 50 entries with explicit error when full
- [x] Sync orchestration lives in a new `MoodSyncService` with no UI logic