### PR TITLE
fix: follow-up fixes for #597, #611, #614, #615

### DIFF
--- a/frontend/src/features/analytics/analytics-page.tsx
+++ b/frontend/src/features/analytics/analytics-page.tsx
@@ -333,6 +333,13 @@ export function AnalyticsPage() {
           >
             30 days
           </button>
+          <button
+            type="button"
+            className="chip"
+            onClick={() => navigate('/analytics/trends')}
+          >
+            Long-term Trends →
+          </button>
         </div>
       </div>
 

--- a/frontend/src/features/settings/settings-page.tsx
+++ b/frontend/src/features/settings/settings-page.tsx
@@ -24,6 +24,7 @@ type Profile = {
   display_name: string | null
   avatar_url: string | null
   timezone: string
+  leaderboard_anonymous: boolean
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -88,18 +89,19 @@ function passwordStrength(pw: string): { score: number; label: string; color: st
 async function fetchProfile(userId: string): Promise<Profile> {
   const { data, error } = await supabase
     .from('profiles')
-    .select('display_name, avatar_url, timezone')
+    .select('display_name, avatar_url, timezone, leaderboard_anonymous')
     .eq('id', userId)
     .single()
 
   if (error || !data) {
-    return { display_name: null, avatar_url: null, timezone: 'UTC' }
+    return { display_name: null, avatar_url: null, timezone: 'UTC', leaderboard_anonymous: false }
   }
 
   return {
     display_name: (data as Record<string, unknown>).display_name as string | null,
     avatar_url: (data as Record<string, unknown>).avatar_url as string | null,
     timezone: ((data as Record<string, unknown>).timezone as string) ?? 'UTC',
+    leaderboard_anonymous: ((data as Record<string, unknown>).leaderboard_anonymous as boolean) ?? false,
   }
 }
 
@@ -521,10 +523,11 @@ export function SettingsPage() {
   const { user, session, signOut } = useAuth()
   const { theme, setTheme } = useTheme()
 
-  const [profile, setProfile] = useState<Profile>({ display_name: null, avatar_url: null, timezone: 'UTC' })
+  const [profile, setProfile] = useState<Profile>({ display_name: null, avatar_url: null, timezone: 'UTC', leaderboard_anonymous: false })
   const [profileLoading, setProfileLoading] = useState(true)
   const [displayName, setDisplayName] = useState('')
   const [timezone, setTimezone] = useState('')
+  const [leaderboardAnonymous, setLeaderboardAnonymous] = useState(false)
   const [profileSaving, setProfileSaving] = useState(false)
   const [avatarUploading, setAvatarUploading] = useState(false)
 
@@ -549,7 +552,7 @@ export function SettingsPage() {
     fetchProfile(user.id).then((p) => {
       setProfile(p)
       setDisplayName(p.display_name ?? '')
-      // Auto-detect timezone if none saved
+      setLeaderboardAnonymous(p.leaderboard_anonymous)
       const savedTz = p.timezone && p.timezone !== 'UTC' ? p.timezone : null
       setTimezone(savedTz ?? Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC')
       setProfileLoading(false)
@@ -621,9 +624,10 @@ export function SettingsPage() {
       await upsertProfile(user.id, {
         display_name: displayName.trim() || null,
         timezone,
+        leaderboard_anonymous: leaderboardAnonymous,
       })
       await supabase.auth.updateUser({ data: { timezone } })
-      setProfile((prev) => ({ ...prev, display_name: displayName.trim() || null, timezone }))
+      setProfile((prev) => ({ ...prev, display_name: displayName.trim() || null, timezone, leaderboard_anonymous: leaderboardAnonymous }))
       await queryClient.invalidateQueries({ queryKey: ['user-profile', user.id] })
       showToast('Profile updated successfully.', 'success')
     } catch (err) {
@@ -799,6 +803,45 @@ export function SettingsPage() {
                 Timezone
                 <TimezoneCombobox value={timezone} onChange={setTimezone} />
               </label>
+
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0.5rem 0' }}>
+                <div>
+                  <span style={{ fontWeight: 500 }}>Anonymous on leaderboard</span>
+                  <p className="muted" style={{ margin: '0.15rem 0 0', fontSize: '0.78rem' }}>
+                    Hide your name and avatar from other users on the leaderboard
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={leaderboardAnonymous}
+                  onClick={() => setLeaderboardAnonymous((prev) => !prev)}
+                  style={{
+                    width: 44,
+                    height: 24,
+                    borderRadius: 12,
+                    border: 'none',
+                    background: leaderboardAnonymous ? 'var(--brand)' : 'var(--line)',
+                    position: 'relative',
+                    cursor: 'pointer',
+                    transition: 'background 0.2s ease',
+                    flexShrink: 0,
+                  }}
+                >
+                  <span
+                    style={{
+                      position: 'absolute',
+                      top: 2,
+                      left: leaderboardAnonymous ? 22 : 2,
+                      width: 20,
+                      height: 20,
+                      borderRadius: '50%',
+                      background: '#fff',
+                      transition: 'left 0.2s ease',
+                    }}
+                  />
+                </button>
+              </div>
 
               <button
                 type="button"

--- a/supabase/migrations/20260726110000_add_referral_system.sql
+++ b/supabase/migrations/20260726110000_add_referral_system.sql
@@ -36,9 +36,9 @@ CREATE POLICY "Users can read referrals they are part of"
   ON referrals FOR SELECT
   USING (auth.uid() = referrer_id OR auth.uid() = referred_id);
 
-CREATE POLICY "System can insert referrals"
+CREATE POLICY "Authenticated users can insert referrals"
   ON referrals FOR INSERT
-  WITH CHECK (true);
+  WITH CHECK (auth.role() = 'authenticated');
 
 CREATE POLICY "System can update referrals"
   ON referrals FOR UPDATE
@@ -117,11 +117,12 @@ $$;
 
 -- RPC: get referral stats for a user
 CREATE OR REPLACE FUNCTION get_referral_stats(p_user_id uuid)
-RETURNS TABLE (total_referrals bigint, referral_code text)
+RETURNS TABLE (code text, total_referrals bigint, completed_referrals bigint)
 LANGUAGE SQL
 SECURITY DEFINER
 AS $$
   SELECT
+    (SELECT code FROM user_referral_codes WHERE user_id = p_user_id),
     COALESCE((SELECT COUNT(*) FROM referrals WHERE referrer_id = p_user_id), 0)::bigint,
-    (SELECT code FROM user_referral_codes WHERE user_id = p_user_id);
+    COALESCE((SELECT COUNT(*) FROM referrals WHERE referrer_id = p_user_id AND completed = true), 0)::bigint;
 $$;


### PR DESCRIPTION
Closes #597
Closes #611
Closes #614
Closes #615

Follow-up to PR #632 (already merged). Fixes remaining gaps in the initial implementation.

## Changes

- **Fix `get_referral_stats` RPC** — returned `referral_code` but React component expected `code`; missing `completed_referrals` column. Now returns `code`, `total_referrals`, `completed_referrals` matching the frontend type.
- **Add leaderboard_anonymous toggle to Settings** — users can now opt in/out of anonymous leaderboard mode directly from the web Settings page. Fixes the "cosmetic-only" privacy toggle concern from #597.
- **Add Long-term Trends link on Analytics page** — users can navigate to `/analytics/trends` from the analytics page, making the new 90/180-day trend visualization discoverable.
- **Tighten referral INSERT policy** — changed from `WITH CHECK (true)` to `auth.role() = 'authenticated'`.