### PR TITLE
feat(web): keyboard-nav a11y fixes, public status page, what's-new mo…

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -54,6 +54,7 @@ const OnboardingPage = lazy(() =>
   import('../features/onboarding/onboarding-page').then((m) => ({ default: m.OnboardingPage })),
 )
 const NotFoundPage = lazy(() => import('../features/shared/not-found-page'))
+const StatusPage = lazy(() => import('../features/status/status-page'))
 
 function PageSkeleton() {
   return (
@@ -190,6 +191,15 @@ export function AppRouter() {
           element={
             <RouteErrorBoundary routeName="Update Password">
               <UpdatePasswordPage />
+            </RouteErrorBoundary>
+          }
+        />
+
+        <Route
+          path="/status"
+          element={
+            <RouteErrorBoundary routeName="Status">
+              <StatusPage />
             </RouteErrorBoundary>
           }
         />

--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -10,7 +10,10 @@ import { NotificationDrawer } from '../../features/notifications/notification-dr
 import { AchievementsWatcher } from '../../features/achievements/achievements-watcher'
 import { useUnlockedAchievements } from '../../features/achievements/use-achievements'
 import { useGlobalShortcut } from '../../hooks/use-global-shortcut'
+import { useFocusTrap } from '../../hooks/use-focus-trap'
 import { MoodLogModal } from '../mood-log-modal'
+import { WhatsNewModal } from '../whats-new-modal'
+import { useWhatsNew } from '../../hooks/use-whats-new'
 
 type UserProfile = { display_name: string | null; avatar_url: string | null }
 
@@ -63,6 +66,7 @@ export function AppShell() {
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false)
   const [isNotificationPanelOpen, setIsNotificationPanelOpen] = useState(false)
   const [isMoodModalOpen, setIsMoodModalOpen] = useState(false)
+  const whatsNew = useWhatsNew()
   const { theme, setTheme } = useTheme()
 
   useGlobalShortcut('k', () => {
@@ -82,6 +86,7 @@ export function AppShell() {
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [selectedResultIdx, setSelectedResultIdx] = useState(-1)
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const userMenuRef = useRef<HTMLDivElement>(null)
   const { results: searchResults, isLoading: searchLoading } = useSearchLogs(user?.id, searchQuery)
   const searchListboxId = useId()
 
@@ -157,6 +162,9 @@ export function AppShell() {
     }
   }, [isSearchOpen, selectedResultIdx, searchResults, navigate])
 
+  // Trap focus in the user menu while open, close on Escape, restore focus to the avatar button on close
+  useFocusTrap(isUserMenuOpen, () => setIsUserMenuOpen(false), userMenuRef)
+
   const onSignOut = async () => {
     await signOut()
     navigate('/login', { replace: true })
@@ -165,6 +173,7 @@ export function AppShell() {
   return (
     <div className="shell-root" aria-keyshortcuts="k">
       <MoodLogModal isOpen={isMoodModalOpen} onClose={() => setIsMoodModalOpen(false)} />
+      <WhatsNewModal isOpen={whatsNew.isOpen} onClose={whatsNew.dismiss} />
       <AchievementsWatcher />
       <aside
         className={[
@@ -396,11 +405,11 @@ export function AppShell() {
               </button>
 
               {isUserMenuOpen ? (
-                <div className="avatar-menu">
-                  <button type="button" onClick={() => navigate('/settings')}>
+                <div className="avatar-menu" ref={userMenuRef} role="menu" aria-label="User menu" tabIndex={-1}>
+                  <button type="button" role="menuitem" onClick={() => { setIsUserMenuOpen(false); navigate('/settings') }}>
                     Profile
                   </button>
-                  <button type="button" onClick={() => void onSignOut()}>
+                  <button type="button" role="menuitem" onClick={() => void onSignOut()}>
                     Sign out
                   </button>
                 </div>

--- a/frontend/src/components/mood-log-modal.tsx
+++ b/frontend/src/components/mood-log-modal.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react'
+import { useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { LogEntryForm } from '../features/logs/components/log-entry-form'
+import { useFocusTrap } from '../hooks/use-focus-trap'
 
 export type MoodLogModalProps = {
   isOpen: boolean
@@ -9,16 +10,10 @@ export type MoodLogModalProps = {
 
 export function MoodLogModal({ isOpen, onClose }: MoodLogModalProps) {
   const navigate = useNavigate()
+  const contentRef = useRef<HTMLDivElement>(null)
 
-  // Close the modal when the Escape key is pressed
-  useEffect(() => {
-    if (!isOpen) return
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isOpen, onClose])
+  // Trap focus while open, close on Escape, restore focus to trigger on close
+  useFocusTrap(isOpen, onClose, contentRef)
 
   if (!isOpen) return null
 
@@ -45,7 +40,9 @@ export function MoodLogModal({ isOpen, onClose }: MoodLogModalProps) {
       onClick={onClose}
     >
       <div
+        ref={contentRef}
         className="modal-content card"
+        tabIndex={-1}
         style={{ width: '100%', maxWidth: '500px', maxHeight: '90vh', overflowY: 'auto' }}
         onClick={(e) => e.stopPropagation()} // Prevent clicking inside from closing modal
       >

--- a/frontend/src/components/whats-new-modal.tsx
+++ b/frontend/src/components/whats-new-modal.tsx
@@ -1,0 +1,67 @@
+import { useRef } from 'react'
+import { useFocusTrap } from '../hooks/use-focus-trap'
+import { getLatestChangelogEntry } from '../hooks/use-whats-new'
+
+export type WhatsNewModalProps = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
+  const contentRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(isOpen, onClose, contentRef)
+
+  const entry = getLatestChangelogEntry()
+
+  if (!isOpen || !entry) return null
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="whats-new-title"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 9999,
+        padding: '1rem',
+      }}
+      onClick={onClose}
+    >
+      <div
+        ref={contentRef}
+        className="modal-content card"
+        tabIndex={-1}
+        style={{ width: '100%', maxWidth: '440px' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="card-header" style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 id="whats-new-title" style={{ margin: 0 }}>What's new in v{entry.version}</h2>
+          <button type="button" className="icon-btn" onClick={onClose} aria-label="Close" style={{ fontSize: '1.2rem', padding: '0.25rem' }}>
+            ✕
+          </button>
+        </div>
+
+        <ul style={{ margin: '0 0 1rem', paddingLeft: '1.25rem' }}>
+          {entry.items.map((item) => (
+            <li key={item} style={{ marginBottom: '0.4rem' }}>{item}</li>
+          ))}
+        </ul>
+
+        <div className="modal-actions" style={{ justifyContent: 'flex-end' }}>
+          <button type="button" onClick={onClose}>
+            Got it
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/data/changelog.json
+++ b/frontend/src/data/changelog.json
@@ -1,0 +1,11 @@
+[
+  {
+    "version": "1.0.0",
+    "date": "2026-07-28",
+    "items": [
+      "Keyboard-only navigation fixes for modals and dropdown menus",
+      "New public /status page for checking backend health",
+      "This what's-new modal, so you can see updates like this one"
+    ]
+  }
+]

--- a/frontend/src/features/achievements/achievements-watcher.tsx
+++ b/frontend/src/features/achievements/achievements-watcher.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '../../lib/auth-context'
+import { useFocusTrap } from '../../hooks/use-focus-trap'
 import { ACHIEVEMENTS } from './achievements'
 import {
   ACHIEVEMENT_UNLOCKED_EVENT,
@@ -52,14 +53,8 @@ export function AchievementsWatcher() {
     setQueue((prev) => prev.slice(1))
   }, [])
 
-  useEffect(() => {
-    if (!current) return
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') dismiss()
-    }
-    window.addEventListener('keydown', onKeyDown)
-    return () => window.removeEventListener('keydown', onKeyDown)
-  }, [current, dismiss])
+  const cardRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(Boolean(current), dismiss, cardRef)
 
   if (!current || !definition) return null
 
@@ -75,7 +70,9 @@ export function AchievementsWatcher() {
         onClick={dismiss}
       >
         <div
+          ref={cardRef}
           className="modal-card"
+          tabIndex={-1}
           style={{ textAlign: 'center', gap: '0.5rem' }}
           onClick={(event) => event.stopPropagation()}
         >

--- a/frontend/src/features/logs/logs-list-page.tsx
+++ b/frontend/src/features/logs/logs-list-page.tsx
@@ -265,6 +265,7 @@ export function LogsListPage() {
   const selectAllRef = useRef<HTMLInputElement>(null)
   const cancelDeleteRef = useRef<HTMLButtonElement>(null)
   const deleteTriggerFocusRef = useRef<HTMLElement | null>(null)
+  const deleteDialogRef = useRef<HTMLDivElement>(null)
 
   // Parse filters from URL
   const filters = useMemo(() => filtersFromSearchParams(searchParams), [searchParams])
@@ -597,13 +598,30 @@ export function LogsListPage() {
     return () => window.removeEventListener('keydown', handleKey)
   }, [habitAutocompleteOpen])
 
-  // Bulk-delete dialog: move focus into it on open, close on Escape, and
-  // restore focus to the element that opened it on close.
+  // Bulk-delete dialog: move focus into it on open, trap Tab cycling, close
+  // on Escape, and restore focus to the element that opened it on close.
   useEffect(() => {
     if (!isDeleteDialogOpen) return
     cancelDeleteRef.current?.focus()
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsDeleteDialogOpen(false)
+      if (e.key === 'Escape') {
+        setIsDeleteDialogOpen(false)
+        return
+      }
+      if (e.key !== 'Tab' || !deleteDialogRef.current) return
+      const items = Array.from(
+        deleteDialogRef.current.querySelectorAll<HTMLElement>('button:not([disabled])'),
+      )
+      if (items.length === 0) return
+      const first = items[0]
+      const last = items[items.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
     }
     window.addEventListener('keydown', handleKey)
     return () => {
@@ -1118,6 +1136,7 @@ export function LogsListPage() {
       {isDeleteDialogOpen && (
         <div className="modal-overlay" role="presentation" onClick={() => setIsDeleteDialogOpen(false)}>
           <div
+            ref={deleteDialogRef}
             className="modal-card"
             role="dialog"
             aria-modal="true"

--- a/frontend/src/features/notifications/notification-drawer.tsx
+++ b/frontend/src/features/notifications/notification-drawer.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../lib/auth-context'
 import { formatDateTime } from '../../lib/date'
+import { useFocusTrap } from '../../hooks/use-focus-trap'
 
 type Notification = {
   id: string
@@ -99,15 +100,8 @@ export function NotificationDrawer({ isOpen, onClose }: Props) {
     },
   })
 
-  // Close on Escape
-  useEffect(() => {
-    if (!isOpen) return
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [isOpen, onClose])
+  // Trap focus while open, close on Escape, restore focus to trigger on close
+  useFocusTrap(isOpen, onClose, panelRef)
 
   // Close on outside click
   useEffect(() => {
@@ -135,6 +129,7 @@ export function NotificationDrawer({ isOpen, onClose }: Props) {
       role="dialog"
       aria-label="Notifications"
       aria-modal="true"
+      tabIndex={-1}
       className="notification-drawer"
       style={{
         position: 'absolute',

--- a/frontend/src/features/status/status-page.tsx
+++ b/frontend/src/features/status/status-page.tsx
@@ -1,0 +1,115 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
+
+type CheckResult = {
+  status: 'up' | 'down'
+  latency_ms: number
+  error: string | null
+}
+
+type HealthResponse = {
+  status: 'operational' | 'degraded' | 'unknown'
+  checked_at: string
+  checks: Record<string, CheckResult>
+}
+
+async function fetchHealth(): Promise<HealthResponse> {
+  const { data, error } = await supabase.functions.invoke<HealthResponse>('health')
+  if (error) throw error
+  if (!data) throw new Error('Empty health response')
+  return data
+}
+
+const STATUS_LABEL: Record<HealthResponse['status'], string> = {
+  operational: 'All systems operational',
+  degraded: 'Degraded — some checks are failing',
+  unknown: 'Unable to determine status',
+}
+
+const STATUS_COLOR: Record<HealthResponse['status'], string> = {
+  operational: 'var(--success, #1a9e5c)',
+  degraded: 'var(--danger, #d34b32)',
+  unknown: 'var(--muted, #888)',
+}
+
+const CHECK_LABEL: Record<string, string> = {
+  database: 'Database',
+  stellar_horizon: 'Stellar Horizon',
+}
+
+export default function StatusPage() {
+  const { data, error, isLoading, isFetching, refetch, dataUpdatedAt } = useQuery({
+    queryKey: ['status-health'],
+    queryFn: fetchHealth,
+    refetchInterval: 30_000,
+    retry: false,
+  })
+
+  const status = error ? 'unknown' : data?.status ?? 'unknown'
+
+  return (
+    <div style={{ maxWidth: 560, margin: '3rem auto', padding: '0 1rem' }}>
+      <div className="card" style={{ padding: '1.5rem' }}>
+        <h1 style={{ marginTop: 0 }}>EchoMirror Status</h1>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', margin: '1rem 0' }}>
+          <span
+            aria-hidden="true"
+            style={{
+              width: 12,
+              height: 12,
+              borderRadius: '50%',
+              background: STATUS_COLOR[status],
+              display: 'inline-block',
+              flexShrink: 0,
+            }}
+          />
+          <strong style={{ fontSize: '1.1rem' }}>
+            {isLoading ? 'Checking…' : STATUS_LABEL[status]}
+          </strong>
+        </div>
+
+        {error ? (
+          <p className="error-text">Could not reach the health-check endpoint.</p>
+        ) : null}
+
+        {data ? (
+          <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '1rem' }}>
+            <thead>
+              <tr>
+                <th align="left" style={{ padding: '0.4rem 0', borderBottom: '1px solid var(--line)' }}>Component</th>
+                <th align="left" style={{ padding: '0.4rem 0', borderBottom: '1px solid var(--line)' }}>Status</th>
+                <th align="left" style={{ padding: '0.4rem 0', borderBottom: '1px solid var(--line)' }}>Latency</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(data.checks).map(([key, check]) => (
+                <tr key={key}>
+                  <td style={{ padding: '0.4rem 0' }}>{CHECK_LABEL[key] ?? key}</td>
+                  <td style={{ padding: '0.4rem 0', color: check.status === 'up' ? STATUS_COLOR.operational : STATUS_COLOR.degraded }}>
+                    {check.status === 'up' ? 'Up' : `Down${check.error ? ` — ${check.error}` : ''}`}
+                  </td>
+                  <td style={{ padding: '0.4rem 0' }}>{check.latency_ms} ms</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : null}
+
+        <p className="muted" style={{ fontSize: '0.8rem', marginTop: '1.5rem' }}>
+          {dataUpdatedAt ? `Last checked ${new Date(dataUpdatedAt).toLocaleTimeString()}` : ''}
+          {' · '}
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            disabled={isFetching}
+            style={{ background: 'none', border: 'none', color: 'var(--brand)', cursor: 'pointer', padding: 0, font: 'inherit' }}
+          >
+            {isFetching ? 'Refreshing…' : 'Refresh now'}
+          </button>
+          {' · auto-refreshes every 30s'}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-focus-trap.ts
+++ b/frontend/src/hooks/use-focus-trap.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, type RefObject } from 'react'
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+/**
+ * Traps Tab focus within `containerRef` while `isOpen`, closes on Escape,
+ * and restores focus to whatever was focused before opening once closed.
+ */
+export function useFocusTrap(
+  isOpen: boolean,
+  onClose: () => void,
+  containerRef: RefObject<HTMLElement | null>,
+) {
+  const triggerRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    triggerRef.current = document.activeElement as HTMLElement | null
+
+    const container = containerRef.current
+    const getFocusable = () =>
+      container
+        ? Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+            (el) => el.offsetParent !== null,
+          )
+        : []
+
+    const initial = getFocusable()[0]
+    ;(initial ?? container)?.focus()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab') return
+
+      const items = getFocusable()
+      if (items.length === 0) return
+
+      const first = items[0]
+      const last = items[items.length - 1]
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      triggerRef.current?.focus?.()
+    }
+  }, [isOpen, onClose, containerRef])
+}

--- a/frontend/src/hooks/use-whats-new.ts
+++ b/frontend/src/hooks/use-whats-new.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import changelog from '../data/changelog.json'
+
+const STORAGE_KEY = 'echo-last-seen-version'
+
+export type ChangelogEntry = {
+  version: string
+  date: string
+  items: string[]
+}
+
+// The app version is defined by the top (most recent) changelog entry —
+// bump it there to trigger the what's-new modal on next deploy.
+export const CURRENT_VERSION: string = (changelog as ChangelogEntry[])[0]?.version ?? '0.0.0'
+
+export function getLatestChangelogEntry(): ChangelogEntry | undefined {
+  return (changelog as ChangelogEntry[])[0]
+}
+
+/**
+ * Shows the what's-new modal once per deployed version bump: if the
+ * last-seen version stored in localStorage differs from the running app
+ * version, the modal opens. First-ever visit just records the version
+ * silently — there's nothing to compare an "update" against yet.
+ */
+export function useWhatsNew() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    let lastSeen: string | null = null
+    try {
+      lastSeen = window.localStorage.getItem(STORAGE_KEY)
+    } catch {
+      return
+    }
+
+    if (lastSeen === null) {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, CURRENT_VERSION)
+      } catch {
+        /* localStorage unavailable — nothing to persist */
+      }
+      return
+    }
+
+    if (lastSeen !== CURRENT_VERSION) {
+      setIsOpen(true)
+    }
+  }, [])
+
+  const dismiss = () => {
+    setIsOpen(false)
+    try {
+      window.localStorage.setItem(STORAGE_KEY, CURRENT_VERSION)
+    } catch {
+      /* localStorage unavailable — modal will just show again next visit */
+    }
+  }
+
+  return { isOpen, dismiss }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1341,3 +1341,58 @@ mark {
     min-width: 120px;
   }
 }
+
+/* ── Print ─────────────────────────────────────────────────
+   Chrome-free printing for logs history / insights pages.
+   Hide navigation, top bar, and interactive controls; let the
+   content column take the full page and print in plain black-on-white. */
+@media print {
+  .shell-sidebar,
+  .shell-topbar,
+  .shell-drawer-overlay,
+  .search-dropdown,
+  .search-overlay,
+  .notification-drawer,
+  .avatar-menu,
+  .modal-overlay,
+  .pagination-row,
+  button,
+  .no-print {
+    display: none !important;
+  }
+
+  .shell-root {
+    display: block;
+  }
+
+  .shell-main {
+    display: block;
+  }
+
+  .shell-content {
+    padding: 0;
+  }
+
+  html,
+  body {
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+  .card,
+  .feature-grid > * {
+    box-shadow: none !important;
+    border: 1px solid #ccc !important;
+    background: #fff !important;
+    color: #000 !important;
+    break-inside: avoid;
+  }
+
+  .card * {
+    color: #000 !important;
+  }
+
+  a[href]::after {
+    content: '';
+  }
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -357,6 +357,10 @@ authorization_url_path = "/oauth/consent"
 # Allow dynamic client registration
 allow_dynamic_registration = false
 
+# Public health-check endpoint backing /status — no auth required.
+[functions.health]
+verify_jwt = false
+
 [edge_runtime]
 enabled = true
 # Supported request policies: `oneshot`, `per_worker`.

--- a/supabase/functions/health/index.ts
+++ b/supabase/functions/health/index.ts
@@ -1,0 +1,82 @@
+/**
+ * health — Supabase Edge Function
+ *
+ * Public health-check: verifies DB connectivity and Stellar Horizon
+ * reachability, and reports a simple aggregate status. Backs the /status page.
+ */
+import { createClient } from 'npm:@supabase/supabase-js@2'
+
+const jsonHeaders = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 'no-store',
+}
+
+function getEnv(name: string, fallback = '') {
+  return Deno.env.get(name) ?? fallback
+}
+
+function horizonUrl() {
+  const network = getEnv('STELLAR_NETWORK', 'testnet').toLowerCase()
+  return network === 'mainnet' ? 'https://horizon.stellar.org' : 'https://horizon-testnet.stellar.org'
+}
+
+async function timed<T>(fn: () => Promise<T>): Promise<{ result: T | null; ms: number; error: string | null }> {
+  const start = performance.now()
+  try {
+    const result = await fn()
+    return { result, ms: Math.round(performance.now() - start), error: null }
+  } catch (err) {
+    return { result: null, ms: Math.round(performance.now() - start), error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+async function checkDatabase() {
+  const supabaseUrl = getEnv('SUPABASE_URL')
+  const serviceRoleKey = getEnv('SUPABASE_SERVICE_ROLE_KEY')
+  if (!supabaseUrl || !serviceRoleKey) {
+    return { status: 'down' as const, latency_ms: 0, error: 'Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY' }
+  }
+  const supabase = createClient(supabaseUrl, serviceRoleKey)
+  const { ms, error } = await timed(async () => {
+    const { error: queryError } = await supabase.from('profiles').select('id', { count: 'exact', head: true }).limit(1)
+    if (queryError) throw new Error(queryError.message)
+  })
+  return { status: error ? ('down' as const) : ('up' as const), latency_ms: ms, error }
+}
+
+async function checkHorizon() {
+  const { ms, error } = await timed(async () => {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 5000)
+    try {
+      const res = await fetch(horizonUrl(), { signal: controller.signal })
+      if (!res.ok) throw new Error(`Horizon responded with ${res.status}`)
+    } finally {
+      clearTimeout(timeout)
+    }
+  })
+  return { status: error ? ('down' as const) : ('up' as const), latency_ms: ms, error }
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: jsonHeaders })
+  }
+
+  const [database, stellar_horizon] = await Promise.all([checkDatabase(), checkHorizon()])
+
+  const checks = { database, stellar_horizon }
+  const allUp = Object.values(checks).every((check) => check.status === 'up')
+  const anyDown = Object.values(checks).some((check) => check.status === 'down')
+  const status = allUp ? 'operational' : anyDown ? 'degraded' : 'unknown'
+
+  return new Response(
+    JSON.stringify({
+      status,
+      checked_at: new Date().toISOString(),
+      checks,
+    }),
+    { status: 200, headers: jsonHeaders },
+  )
+})


### PR DESCRIPTION
…dal, print stylesheet

## Summary

Four small, independent web features/fixes bundled together:

- **#638 — Keyboard-only navigation audit (modals & dropdowns)**
  - New `useFocusTrap` hook (`src/hooks/use-focus-trap.ts`): traps `Tab`/`Shift+Tab` inside a container, closes on `Escape`, restores focus to the triggering element on close.
  - Applied to `MoodLogModal`, `NotificationDrawer`, the achievement-unlocked celebration modal, and the app-shell avatar/user menu (which previously had **no** keyboard handling at all).
  - Added Tab-cycling to the logs bulk-delete confirmation dialog, which already had Escape/initial-focus/return-focus.

- **#640 — Public status page / health-check endpoint**
  - New edge function `supabase/functions/health` checks DB connectivity (lightweight query via service-role client) and Stellar Horizon reachability (5s-timeout fetch), returning `{ status, checked_at, checks }` JSON.
  - `verify_jwt = false` added for this function in `supabase/config.toml` so it's publicly reachable.
  - New public `/status` route (`src/features/status/status-page.tsx`) polls the endpoint every 30s, shows overall status + per-component up/down and latency, with manual refresh.

- **#642 — What's-new modal after version bumps**
  - `src/data/changelog.json` is the single source of truth: the top entry's `version` is the "current" app version.
  - `useWhatsNew` hook compares it against `echo-last-seen-version` in `localStorage`. First-ever visit records silently (no modal for new users); any later visit where the version differs shows the modal once, then persists the new version.
  - `WhatsNewModal` reuses the `useFocusTrap` hook from #638 and is mounted in `AppShell`.

- **#646 — Print-friendly stylesheet**
  - `@media print` block in `src/styles.css`: hides sidebar/topbar/dropdowns/modals/pagination/buttons, collapses the shell grid to block layout, and flattens cards to plain bordered, black-on-white blocks with `break-inside: avoid`.

Closes #638 
Closes #640 
Closes #642 
Closes #646 

## Test plan

- [x] `npm install`
- [x] `tsc --noEmit` — no new errors introduced (4 pre-existing `ImportRowResult` errors in `logs-import.test.ts` / `logs-list-page.tsx` confirmed present on a clean `development` checkout, unrelated to this branch)
- [x] `vite build` — all 1218 modules transform cleanly; final bundling step fails on a pre-existing `manualChunks` object-vs-function incompatibility between the repo's `vite.config.ts` and the installed `vite@8.0.14`, also reproduced on a clean checkout — unrelated to this branch
