### PR TITLE
feat: mood log image attachments, maintenance banner, backup runbook,…

### DIFF
--- a/docs/backup-restore-runbook.md
+++ b/docs/backup-restore-runbook.md
@@ -1,0 +1,85 @@
+# Issue #649: Database Backup Verification & Restore Runbook
+
+## Problem
+
+It was unclear whether Supabase's automated backups had ever been test-restored. An untested backup is not a real recovery guarantee — this doc records the current backup configuration, gives a repeatable restore-drill procedure, and provides a runbook to follow during a real incident.
+
+## Current Backup Configuration
+
+Supabase-hosted backup settings (frequency, retention, point-in-time recovery) are managed entirely in the **Supabase Dashboard** (`Project Settings → Database → Backups`), not in this repository. `supabase/config.toml` only configures the local CLI/Docker stack and has no backup section — there is nothing to read from the repo about backup schedule or retention.
+
+This repo also has no project ref, staging project, or production project name checked in anywhere (`supabase/README.md` only shows a generic `supabase link --project-ref <your-project-ref>` placeholder), and there is no CI/CD pipeline that deploys migrations to a hosted project — `.github/workflows/ci.yml` only runs `supabase start` / `supabase test db` against an ephemeral local instance. Migrations are pushed manually via `supabase db push` per `supabase/README.md`.
+
+**Action for the project owner:** fill in the table below from the Dashboard for whichever hosted project(s) exist (fields depend on plan tier — Free tier has no automated backups; Pro and above include daily backups with point-in-time recovery available on higher tiers).
+
+| Field | Value |
+|---|---|
+| Project ref | _fill in_ |
+| Plan tier | _fill in_ |
+| Backup frequency | _fill in (Dashboard → Database → Backups)_ |
+| Retention window | _fill in_ |
+| Point-in-time recovery (PITR) enabled | _fill in_ |
+
+### Other operational state a restore must account for
+
+- Several migrations register `pg_cron` jobs (`send-weekly-digest`, `send-daily-reminder`, the 2 AM UTC hard-delete purge job). Scheduled jobs are **not** part of a database backup/restore in the same way as table data on some Supabase plans — verify they still exist and are scheduled after any restore (`select * from cron.job;`).
+- Storage buckets (`avatars`, `log-images`, `stories`, `videos`, `images`, etc.) and their objects are backed up separately from the Postgres database on Supabase. Confirm storage objects, not just rows referencing them, come back after a restore.
+- Edge Functions (`supabase/functions/*`) are deployed independently of the database and are unaffected by a database restore, but any function that depends on a table/row that didn't come back (e.g. `create-stellar-wallet`'s webhook target) should be re-verified.
+
+## Restore Drill Procedure
+
+Run this against a **disposable staging project**, never against production.
+
+1. **Create a scratch Supabase project** in the Dashboard (free tier is fine for structure/data-integrity checks).
+2. **Restore into it**, using whichever method matches the source project's plan:
+   - If PITR/automated backups are enabled on the source project: use Dashboard → Database → Backups → Restore, targeting the scratch project (or follow Supabase's cross-project restore docs for your plan).
+   - If no automated backups exist (e.g. Free tier): treat the migration history itself as the recovery mechanism — this drill instead validates that `supabase/migrations/*.sql` can rebuild the schema from empty, which is what fixing the "no backups" gap in the future will end up depending on regardless.
+3. **Link and apply migrations to the scratch project:**
+   ```bash
+   supabase link --project-ref <scratch-project-ref>
+   supabase db push
+   ```
+4. **Verify data integrity:**
+   ```sql
+   -- Row counts on the tables listed in supabase/README.md's troubleshooting section
+   select 'log_entries', count(*) from public.log_entries
+   union all select 'profiles', count(*) from public.profiles
+   union all select 'mood_comment_notifications', count(*) from public.mood_comment_notifications
+   union all select 'user_wallets', count(*) from public.user_wallets
+   union all select 'gift_transactions', count(*) from public.gift_transactions;
+
+   -- Spot-check a known row (adjust to a real id from the source project)
+   select * from public.log_entries where id = '<known-id>';
+
+   -- Cron jobs re-registered
+   select jobname, schedule, active from cron.job;
+   ```
+5. **Verify RLS still enforces access control** — confirm `select * from pg_policies where schemaname = 'public';` returns the expected policies (row-level security is defined in migrations, so it comes back automatically via `db push`, but confirm it wasn't skipped).
+6. **Record the result** (date run, who ran it, source project, scratch project, pass/fail, any gaps found) at the bottom of this doc or in the team's incident-tracking tool, and tear down the scratch project.
+
+**Status:** this runbook has not yet been executed against a live project — no hosted project ref/credentials were available to run it end-to-end while writing this doc. The next maintainer with Dashboard access to the production project should run the drill above and record the result in the table below.
+
+| Date | Run by | Source project | Result | Notes |
+|---|---|---|---|---|
+| _pending_ | _pending_ | _pending_ | _pending_ | First drill not yet run — see Status above |
+
+## Real Recovery Runbook
+
+Follow this during an actual incident (data loss, corruption, or a bad migration in production).
+
+1. **Stop the bleeding first.** If a bad migration or query is actively corrupting data, pause writes if possible (e.g. rotate the app's `SUPABASE_ANON_KEY`/service key, or put the app in maintenance mode using the flag from issue #652) before starting recovery.
+2. **Identify the target recovery point** — the latest known-good timestamp or backup, based on when the incident started.
+3. **Restore via Dashboard → Database → Backups** to either the same project (in-place restore, if the plan supports it) or a fresh project you'll cut over to. Restoring into a fresh project first and validating before cutover is safer when time allows.
+4. **Re-apply any migrations newer than the restored backup:**
+   ```bash
+   supabase link --project-ref <project-ref>
+   supabase db push
+   ```
+5. **Re-verify cron jobs, storage buckets, and Edge Function secrets** as in step 4 of the drill above — these do not always travel with a database-only restore.
+6. **Smoke test the app** against the restored project (login, create a log entry, check leaderboard/wallet reads) before pointing production traffic at it.
+7. **Turn off maintenance mode** (issue #652 banner) once verified.
+8. **Write a postmortem**: what was lost (if anything, by timestamp), root cause, and any gap this incident revealed in the drill procedure above — feed corrections back into this doc.
+
+## Related Issues
+
+- #652 — maintenance-mode banner, useful as step 1 of the real-recovery runbook above.

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { AppShell } from '../components/layout/app-shell'
+import { MaintenanceBanner } from '../components/maintenance-banner'
 import { SignInPanel } from '../components/auth/sign-in-panel'
 import { LandingPage } from '../features/landing/LandingPage'
 import { SignupPage } from '../features/auth/pages/SignupPage'
@@ -143,7 +144,9 @@ export function AppRouter() {
   const { user } = useAuth()
 
   return (
-    <Suspense fallback={<PageSkeleton />}>
+    <>
+      <MaintenanceBanner />
+      <Suspense fallback={<PageSkeleton />}>
       <Routes>
         <Route
           path="/"
@@ -319,6 +322,7 @@ export function AppRouter() {
           }
         />
       </Routes>
-    </Suspense>
+      </Suspense>
+    </>
   )
 }

--- a/frontend/src/components/maintenance-banner.tsx
+++ b/frontend/src/components/maintenance-banner.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+import { useMaintenanceStatus } from '../hooks/use-maintenance-status'
+
+const DISMISS_KEY = 'echo-maintenance-dismissed'
+
+function formatExpectedEnd(value: string | null): string | null {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+}
+
+export function MaintenanceBanner() {
+  const { data } = useMaintenanceStatus()
+  const signature = data ? `${data.message ?? ''}|${data.expected_end_at ?? ''}` : ''
+  const [dismissedSignature, setDismissedSignature] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (typeof sessionStorage === 'undefined') return
+    setDismissedSignature(sessionStorage.getItem(DISMISS_KEY))
+  }, [])
+
+  if (!data?.enabled || dismissedSignature === signature) {
+    return null
+  }
+
+  const endLabel = formatExpectedEnd(data.expected_end_at)
+
+  return (
+    <div
+      role="alert"
+      style={{
+        padding: '0.75rem 1.25rem',
+        background: 'color-mix(in srgb, var(--warning) 14%, transparent)',
+        borderBottom: '1px solid color-mix(in srgb, var(--warning) 35%, transparent)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '1rem',
+        flexWrap: 'wrap',
+        textAlign: 'center',
+      }}
+    >
+      <p style={{ margin: 0, fontSize: '0.9rem', color: 'var(--warning)' }}>
+        <strong>Scheduled maintenance:</strong>{' '}
+        {data.message?.trim() || 'The app is undergoing scheduled maintenance.'}
+        {endLabel ? ` Expected to end ${endLabel}.` : ''}
+      </p>
+      <button
+        type="button"
+        onClick={() => {
+          if (typeof sessionStorage !== 'undefined') {
+            sessionStorage.setItem(DISMISS_KEY, signature)
+          }
+          setDismissedSignature(signature)
+        }}
+        style={{
+          padding: '0.3rem 0.75rem',
+          borderRadius: '8px',
+          border: '1px solid color-mix(in srgb, var(--warning) 45%, transparent)',
+          background: 'transparent',
+          color: 'var(--warning)',
+          cursor: 'pointer',
+          fontSize: '0.8rem',
+        }}
+      >
+        Dismiss
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/analytics/analytics-helpers.ts
+++ b/frontend/src/features/analytics/analytics-helpers.ts
@@ -2,7 +2,7 @@ import { daysAgo } from '../../lib/date'
 import { supabase } from '../../lib/supabase'
 import type { LogEntry } from '../../lib/types'
 
-export type AnalyticsLogEntry = Omit<LogEntry, 'habits'> & {
+export type AnalyticsLogEntry = Omit<LogEntry, 'habits' | 'image_path'> & {
   habits: string[] | null
 }
 

--- a/frontend/src/features/logs/components/log-image-thumbnail.tsx
+++ b/frontend/src/features/logs/components/log-image-thumbnail.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query'
+import { getLogImageSignedUrl } from '../../../lib/log-images'
+
+export function LogImageThumbnail({
+  path,
+  alt,
+  size = 44,
+}: {
+  path: string
+  alt: string
+  size?: number
+}) {
+  const { data: url } = useQuery({
+    queryKey: ['log-image-url', path],
+    queryFn: () => getLogImageSignedUrl(path),
+    staleTime: 50 * 60 * 1000,
+  })
+
+  if (!url) {
+    return null
+  }
+
+  return (
+    <img
+      src={url}
+      alt={alt}
+      style={{
+        width: size,
+        height: size,
+        objectFit: 'cover',
+        borderRadius: '8px',
+        border: '1px solid var(--line)',
+        flexShrink: 0,
+      }}
+    />
+  )
+}

--- a/frontend/src/features/logs/log-detail-page.tsx
+++ b/frontend/src/features/logs/log-detail-page.tsx
@@ -5,6 +5,7 @@ import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../lib/auth-context'
 import type { LogEntry } from '../../lib/types'
 import { moodToEmoji } from '../../lib/date'
+import { LogImageThumbnail } from './components/log-image-thumbnail'
 
 const MOOD_COLORS: Record<number, string> = {
   1: '#ef4444',
@@ -209,6 +210,13 @@ export function LogDetailPage() {
             <div>
               <p className="field-label">Notes</p>
               <p style={{ whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{entry.notes}</p>
+            </div>
+          ) : null}
+
+          {entry.image_path ? (
+            <div>
+              <p className="field-label">Photo</p>
+              <LogImageThumbnail path={entry.image_path} alt="Log entry attachment" size={220} />
             </div>
           ) : null}
 

--- a/frontend/src/features/logs/log-form-page.tsx
+++ b/frontend/src/features/logs/log-form-page.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, KeyboardEvent, useEffect, useMemo, useState } from 'react'
+import { FormEvent, KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { supabase } from '../../lib/supabase'
@@ -6,6 +6,13 @@ import { useAuth } from '../../lib/auth-context'
 import { useToast } from '../../lib/use-toast'
 import type { LogEntry } from '../../lib/types'
 import { toDateInputValue } from '../../lib/date'
+import {
+  ALLOWED_LOG_IMAGE_TYPES,
+  MAX_LOG_IMAGE_BYTES,
+  getLogImageSignedUrl,
+  removeLogImage,
+  uploadLogImage,
+} from '../../lib/log-images'
 
 type LogFormMode = 'create' | 'edit'
 
@@ -86,6 +93,20 @@ export function LogFormPage({ mode }: LogFormPageProps) {
   const [toast, setToast] = useState<{ show: boolean; message: string; type: 'success' | 'error' } | null>(null)
   const [fieldErrors, setFieldErrors] = useState<{ date?: string; mood?: string; habits?: string; notes?: string }>({})
 
+  const imageInputRef = useRef<HTMLInputElement>(null)
+  const [existingImagePath, setExistingImagePath] = useState<string | null>(null)
+  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null)
+  const [removeExistingImage, setRemoveExistingImage] = useState(false)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const [imageDragOver, setImageDragOver] = useState(false)
+
+  const existingImageUrlQuery = useQuery({
+    queryKey: ['log-image-url', existingImagePath],
+    queryFn: () => getLogImageSignedUrl(existingImagePath!),
+    enabled: Boolean(existingImagePath) && !removeExistingImage,
+  })
+
   const hydrated = useMemo(
     () =>
       mode === 'edit' && existingEntry
@@ -94,6 +115,7 @@ export function LogFormPage({ mode }: LogFormPageProps) {
             mood: existingEntry.mood,
             habits: existingEntry.habits,
             notes: existingEntry.notes ?? '',
+            imagePath: existingEntry.image_path,
           }
         : null,
     [mode, existingEntry],
@@ -108,7 +130,42 @@ export function LogFormPage({ mode }: LogFormPageProps) {
     setMood(hydrated.mood)
     setHabits(hydrated.habits)
     setNotes(hydrated.notes)
+    setExistingImagePath(hydrated.imagePath)
   }, [hydrated])
+
+  useEffect(() => {
+    return () => {
+      if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl)
+    }
+  }, [imagePreviewUrl])
+
+  function selectImageFile(file: File) {
+    setImageError(null)
+    if (!ALLOWED_LOG_IMAGE_TYPES.includes(file.type)) {
+      setImageError('Only PNG, JPG, or WEBP images are allowed.')
+      return
+    }
+    if (file.size > MAX_LOG_IMAGE_BYTES) {
+      setImageError(`File is ${(file.size / 1024 / 1024).toFixed(1)} MB — max is 5 MB.`)
+      return
+    }
+    if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl)
+    setImageFile(file)
+    setImagePreviewUrl(URL.createObjectURL(file))
+    setRemoveExistingImage(false)
+  }
+
+  function clearImage() {
+    if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl)
+    setImageFile(null)
+    setImagePreviewUrl(null)
+    setImageError(null)
+    if (existingImagePath) {
+      setRemoveExistingImage(true)
+    }
+  }
+
+  const displayedImageUrl = imagePreviewUrl ?? (!removeExistingImage ? existingImageUrlQuery.data ?? null : null)
 
   function validate(): boolean {
     const errors: { date?: string; mood?: string; habits?: string; notes?: string } = {}
@@ -134,6 +191,8 @@ export function LogFormPage({ mode }: LogFormPageProps) {
         throw new Error('No signed in user found.')
       }
 
+      let entry: LogEntry
+
       if (mode === 'create') {
         const existingId = await findExistingByDate(user.id, date)
         if (existingId) {
@@ -157,27 +216,53 @@ export function LogFormPage({ mode }: LogFormPageProps) {
           throw error
         }
 
-        return data as LogEntry
+        entry = data as LogEntry
+      } else {
+        const { data, error } = await supabase
+          .from('log_entries')
+          .update({
+            date: new Date(`${date}T12:00:00.000Z`).toISOString(),
+            mood,
+            habits,
+            notes: notes.trim() || null,
+          })
+          .eq('id', id)
+          .eq('user_id', user.id)
+          .select('*')
+          .single()
+
+        if (error) {
+          throw error
+        }
+
+        entry = data as LogEntry
       }
 
-      const { data, error } = await supabase
-        .from('log_entries')
-        .update({
-          date: new Date(`${date}T12:00:00.000Z`).toISOString(),
-          mood,
-          habits,
-          notes: notes.trim() || null,
-        })
-        .eq('id', id)
-        .eq('user_id', user.id)
-        .select('*')
-        .single()
-
-      if (error) {
-        throw error
+      let imagePath = entry.image_path
+      if (removeExistingImage && existingImagePath) {
+        await removeLogImage(existingImagePath).catch(() => {})
+        imagePath = null
+      }
+      if (imageFile) {
+        imagePath = await uploadLogImage(user.id, entry.id, imageFile)
       }
 
-      return data as LogEntry
+      if (imagePath !== entry.image_path) {
+        const { data: updated, error: imageUpdateError } = await supabase
+          .from('log_entries')
+          .update({ image_path: imagePath })
+          .eq('id', entry.id)
+          .select('*')
+          .single()
+
+        if (imageUpdateError) {
+          throw imageUpdateError
+        }
+
+        entry = updated as LogEntry
+      }
+
+      return entry
     },
     onMutate: () => {
       setFormError(null)
@@ -188,6 +273,7 @@ export function LogFormPage({ mode }: LogFormPageProps) {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['logs', user?.id] }),
         queryClient.invalidateQueries({ queryKey: ['log-entry', id] }),
+        queryClient.invalidateQueries({ queryKey: ['log-image-url'] }),
       ])
       showToast(mode === 'create' ? 'Mood logged! +1 ECHO earned 🎉' : 'Changes saved', 'success')
       navigate('/logs')
@@ -381,6 +467,65 @@ export function LogFormPage({ mode }: LogFormPageProps) {
             </span>
             {fieldErrors.notes && <p className="error-text" style={{ marginTop: '0.25rem' }}>{fieldErrors.notes}</p>}
           </label>
+
+          <div>
+            <p className="field-label">Photo (optional)</p>
+            {displayedImageUrl ? (
+              <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.75rem', marginTop: '0.45rem' }}>
+                <img
+                  src={displayedImageUrl}
+                  alt="Log entry attachment preview"
+                  style={{ width: 96, height: 96, objectFit: 'cover', borderRadius: '10px', border: '1px solid var(--line)' }}
+                />
+                <button type="button" className="secondary" onClick={clearImage}>
+                  Remove photo
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => imageInputRef.current?.click()}
+                onDragOver={(event) => { event.preventDefault(); setImageDragOver(true) }}
+                onDragLeave={() => setImageDragOver(false)}
+                onDrop={(event) => {
+                  event.preventDefault()
+                  setImageDragOver(false)
+                  const file = event.dataTransfer.files[0]
+                  if (file) selectImageFile(file)
+                }}
+                style={{
+                  marginTop: '0.45rem',
+                  padding: '0.6rem 1rem',
+                  borderRadius: '8px',
+                  border: `1px dashed ${imageDragOver ? 'var(--brand)' : 'var(--line)'}`,
+                  background: imageDragOver ? 'var(--surface-soft)' : 'transparent',
+                  cursor: 'pointer',
+                  fontSize: '0.85rem',
+                  color: 'var(--text)',
+                  width: '100%',
+                  textAlign: 'center',
+                }}
+              >
+                Drag & drop a photo, or click to browse
+              </button>
+            )}
+            <p className="muted" style={{ margin: '0.35rem 0 0', fontSize: '0.75rem' }}>
+              PNG, JPG, or WEBP, max 5 MB
+            </p>
+            {imageError && <p className="error-text" style={{ marginTop: '0.25rem' }}>{imageError}</p>}
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              style={{ display: 'none' }}
+              aria-label="Attach a photo to this log entry"
+              onChange={(event) => {
+                const file = event.target.files?.[0]
+                if (file) selectImageFile(file)
+                event.target.value = ''
+              }}
+            />
+          </div>
 
           <button type="submit" disabled={saveMutation.isPending} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'center' }}>
             {saveMutation.isPending && (

--- a/frontend/src/features/logs/logs-list-page.test.tsx
+++ b/frontend/src/features/logs/logs-list-page.test.tsx
@@ -31,6 +31,7 @@ function makeEntry(overrides: Partial<LogEntry> = {}): LogEntry {
     mood: 4,
     habits: ['Exercise'],
     notes: 'Morning run felt good',
+    image_path: null,
     created_at: '2026-06-01T13:00:00.000Z',
     updated_at: '2026-06-01T13:00:00.000Z',
     ...overrides,

--- a/frontend/src/features/logs/logs-list-page.tsx
+++ b/frontend/src/features/logs/logs-list-page.tsx
@@ -14,6 +14,7 @@ import {
   type ImportRow,
 } from './logs-import'
 import { SORT_OPTIONS, DEFAULT_SORT, isSortOption, splitOnMatch, type SortOption } from './logs-utils'
+import { LogImageThumbnail } from './components/log-image-thumbnail'
 
 const LOGS_PAGE_SIZE = 10
 const LOGS_SCROLL_STORAGE_KEY = 'echomirror:logs-scroll-y'
@@ -1058,7 +1059,14 @@ export function LogsListPage() {
                     ))}
                   </div>
 
-                  <p className="muted note-preview">{renderNotePreview(entry.notes, debouncedSearch)}</p>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
+                    {entry.image_path ? (
+                      <LogImageThumbnail path={entry.image_path} alt="" size={40} />
+                    ) : null}
+                    <p className="muted note-preview" style={{ margin: 0 }}>
+                      {renderNotePreview(entry.notes, debouncedSearch)}
+                    </p>
+                  </div>
                 </Link>
               </div>
             )

--- a/frontend/src/hooks/use-maintenance-status.ts
+++ b/frontend/src/hooks/use-maintenance-status.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../lib/supabase'
+
+export type MaintenanceStatus = {
+  enabled: boolean
+  message: string | null
+  expected_end_at: string | null
+}
+
+async function fetchMaintenanceStatus(): Promise<MaintenanceStatus | null> {
+  const { data, error } = await supabase
+    .from('app_maintenance')
+    .select('enabled, message, expected_end_at')
+    .eq('id', 1)
+    .maybeSingle()
+
+  if (error || !data) {
+    return null
+  }
+
+  return data as MaintenanceStatus
+}
+
+export function useMaintenanceStatus() {
+  return useQuery({
+    queryKey: ['maintenance-status'],
+    queryFn: fetchMaintenanceStatus,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  })
+}

--- a/frontend/src/lib/log-images.ts
+++ b/frontend/src/lib/log-images.ts
@@ -1,0 +1,31 @@
+import { supabase } from './supabase'
+
+export const LOG_IMAGE_BUCKET = 'log-images'
+export const MAX_LOG_IMAGE_BYTES = 5 * 1024 * 1024
+export const ALLOWED_LOG_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/webp']
+
+export async function uploadLogImage(userId: string, entryId: string, file: File): Promise<string> {
+  const ext = file.name.split('.').pop() ?? 'jpg'
+  const path = `${userId}/${entryId}.${ext}`
+
+  const { error } = await supabase.storage
+    .from(LOG_IMAGE_BUCKET)
+    .upload(path, file, { upsert: true, contentType: file.type })
+
+  if (error) throw error
+  return path
+}
+
+export async function removeLogImage(path: string): Promise<void> {
+  const { error } = await supabase.storage.from(LOG_IMAGE_BUCKET).remove([path])
+  if (error) throw error
+}
+
+export async function getLogImageSignedUrl(path: string): Promise<string | null> {
+  const { data, error } = await supabase.storage
+    .from(LOG_IMAGE_BUCKET)
+    .createSignedUrl(path, 3600)
+
+  if (error) return null
+  return data.signedUrl
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -36,6 +36,7 @@ export type LogEntry = {
   mood: number | null
   habits: string[]
   notes: string | null
+  image_path: string | null
   created_at: string
   updated_at: string
 }

--- a/lib/features/logging/view/screens/create_entry_screen.dart
+++ b/lib/features/logging/view/screens/create_entry_screen.dart
@@ -100,12 +100,7 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
     final authState = ref.read(authProvider);
     if (!authState.isAuthenticated || authState.user == null) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Please log in to create entries'),
-            backgroundColor: AppTheme.errorColor,
-          ),
-        );
+        ErrorHandler.showError(context, 'Please log in to create entries');
       }
       return;
     }
@@ -155,14 +150,9 @@ class _CreateEntryScreenState extends ConsumerState<CreateEntryScreen> {
                 .shareMood(sentiment);
             debugPrint('[CreateEntryScreen] Share mood result: $shareResult');
             if (!shareResult && mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: const Text(
-                    'Failed to share mood. Check location permissions.',
-                  ),
-                  backgroundColor: Colors.orange,
-                  duration: const Duration(seconds: 3),
-                ),
+              ErrorHandler.showError(
+                context,
+                'Failed to share mood. Check location permissions.',
               );
             }
           } else {

--- a/lib/features/settings/view/screens/change_password_screen.dart
+++ b/lib/features/settings/view/screens/change_password_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/themes/app_theme.dart';
+import '../../../../core/utils/error_handler.dart';
 import '../../../auth/view/widgets/custom_button.dart';
 import '../../../auth/view/widgets/custom_text_field.dart';
 import '../../../auth/viewmodel/providers/auth_provider.dart';
@@ -53,16 +54,12 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
           _newPasswordController.clear();
           _confirmPasswordController.clear();
 
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Password updated successfully')),
-          );
+          ErrorHandler.showSuccess(context, 'Password updated successfully');
           context.pop();
         } else {
           final error =
               ref.read(authProvider).error ?? 'Failed to update password';
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text(error)));
+          ErrorHandler.showError(context, error);
         }
       }
     }

--- a/lib/features/settings/view/screens/security_screen.dart
+++ b/lib/features/settings/view/screens/security_screen.dart
@@ -7,6 +7,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import '../../../../core/themes/app_theme.dart';
+import '../../../../core/utils/error_handler.dart';
 
 class SecurityScreen extends ConsumerStatefulWidget {
   const SecurityScreen({super.key});
@@ -118,9 +119,7 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
       if (sessionId == 'current') {
         await client.auth.signOut();
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Signed out successfully')),
-          );
+          ErrorHandler.showSuccess(context, 'Signed out successfully');
         }
         return;
       }
@@ -132,16 +131,12 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
           .eq('user_id', client.auth.currentUser!.id);
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Session revoked')),
-        );
+        ErrorHandler.showSuccess(context, 'Session revoked');
         await _loadSessions();
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error: ${e.toString()}')),
-        );
+        ErrorHandler.showError(context, ErrorHandler.getErrorMessage(e));
       }
     }
   }
@@ -184,18 +179,15 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
         }
 
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('All other sessions have been signed out'),
-            ),
+          ErrorHandler.showSuccess(
+            context,
+            'All other sessions have been signed out',
           );
           await _loadSessions();
         }
       } catch (e) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Error: ${e.toString()}')),
-          );
+          ErrorHandler.showError(context, ErrorHandler.getErrorMessage(e));
         }
       } finally {
         if (mounted) setState(() => _isSigningOutAll = false);
@@ -229,8 +221,9 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error enabling 2FA: ${e.toString()}')),
+        ErrorHandler.showError(
+          context,
+          'Error enabling 2FA: ${ErrorHandler.getErrorMessage(e)}',
         );
       }
     }
@@ -352,16 +345,15 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
           }
 
           if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('2FA disabled successfully')),
-            );
+            ErrorHandler.showSuccess(context, '2FA disabled successfully');
             await _checkMfaStatus();
           }
         }
       } catch (e) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Error disabling 2FA: ${e.toString()}')),
+          ErrorHandler.showError(
+            context,
+            'Error disabling 2FA: ${ErrorHandler.getErrorMessage(e)}',
           );
         }
       }
@@ -418,7 +410,13 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
         FilledButton(
           onPressed: () async {
             final code = totpController.text.trim();
-            if (code.length != 6 || _mfaFactorId == null) return;
+            if (code.length != 6 || _mfaFactorId == null) {
+              ErrorHandler.showError(
+                context,
+                'Please enter the 6-digit code from your authenticator app',
+              );
+              return;
+            }
 
             try {
               final client = Supabase.instance.client;
@@ -433,8 +431,9 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
 
               Navigator.pop(context, true);
             } catch (e) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Verification failed: ${e.toString()}')),
+              ErrorHandler.showError(
+                context,
+                'Verification failed: ${ErrorHandler.getErrorMessage(e)}',
               );
             }
           },

--- a/supabase/migrations/20260727010000_issue_650_log_entry_images.sql
+++ b/supabase/migrations/20260727010000_issue_650_log_entry_images.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- Issue #650: optional image attachment on mood log entries
+-- ============================================================
+
+alter table public.log_entries
+  add column if not exists image_path text;
+
+-- Private bucket: images are NOT publicly readable, only the
+-- owning user can read/write their own files (RLS below).
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values ('log-images', 'log-images', false, 5242880, array['image/png', 'image/jpeg', 'image/webp'])
+on conflict (id) do update set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+do $$
+begin
+  create policy "Users can read own log images"
+    on storage.objects for select
+    using (bucket_id = 'log-images' and auth.uid()::text = (storage.foldername(name))[1]);
+exception
+  when duplicate_object then null;
+end $$;
+
+do $$
+begin
+  create policy "Users can upload own log images"
+    on storage.objects for insert
+    with check (bucket_id = 'log-images' and auth.uid()::text = (storage.foldername(name))[1]);
+exception
+  when duplicate_object then null;
+end $$;
+
+do $$
+begin
+  create policy "Users can update own log images"
+    on storage.objects for update
+    using (bucket_id = 'log-images' and auth.uid()::text = (storage.foldername(name))[1])
+    with check (bucket_id = 'log-images' and auth.uid()::text = (storage.foldername(name))[1]);
+exception
+  when duplicate_object then null;
+end $$;
+
+do $$
+begin
+  create policy "Users can delete own log images"
+    on storage.objects for delete
+    using (bucket_id = 'log-images' and auth.uid()::text = (storage.foldername(name))[1]);
+exception
+  when duplicate_object then null;
+end $$;

--- a/supabase/migrations/20260727020000_issue_652_maintenance_mode.sql
+++ b/supabase/migrations/20260727020000_issue_652_maintenance_mode.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- Issue #652: maintenance-mode banner remote-config flag
+-- ============================================================
+
+create table if not exists public.app_maintenance (
+  id int primary key default 1,
+  enabled boolean not null default false,
+  message text,
+  expected_end_at timestamptz,
+  updated_at timestamptz not null default now(),
+  constraint app_maintenance_singleton check (id = 1)
+);
+
+-- Seed the single config row if it doesn't exist yet.
+insert into public.app_maintenance (id, enabled)
+values (1, false)
+on conflict (id) do nothing;
+
+alter table public.app_maintenance enable row level security;
+
+-- Readable by anyone (including signed-out visitors) so the banner
+-- can show before login. Toggling `enabled`/`message`/`expected_end_at`
+-- is done via the Supabase dashboard (service role bypasses RLS) —
+-- no insert/update/delete policy is granted to regular users.
+do $$
+begin
+  create policy "Anyone can read maintenance status"
+    on public.app_maintenance for select
+    using (true);
+exception
+  when duplicate_object then null;
+end $$;


### PR DESCRIPTION
  ## Summary

  Four independent issues addressed in one branch:

  ### #650 — Drag-and-drop image attachment on mood log notes (web)
  - New private Supabase Storage bucket (`log-images`, 5MB limit, png/jpeg/webp) with
  owner-scoped RLS policies (select/insert/update/delete) — not publicly readable, matches the
  existing `avatars` bucket migration pattern
  - `image_path` column added to `log_entries`
  - Drag-and-drop / click-to-browse attach control on the log entry form (`/logs/new`,
  `/logs/:id/edit`), with client-side type/size validation and a remove option
  - Thumbnail shown in log history rows and a larger preview in the log detail view, both loaded
  via short-lived signed URLs (bucket is private)

  ### #652 — Maintenance-mode banner (web)
  - New `app_maintenance` table (single config row), readable by anyone via RLS, writable only
  via the Supabase dashboard (service role) — toggling it requires no deploy
  - Dismissible banner polled every 60s, mounted at the app root so it's visible to both
  signed-out and signed-in users
  - Re-appears if the maintenance message/end-time changes even if previously dismissed

  ### #649 — Backup verification / restore drill documentation
  - `docs/backup-restore-runbook.md`: documents that backup config is Supabase-dashboard-managed
  project, and a real-incident recovery runbook
  - No hosted project credentials were available in this environment, so the drill itself has not
  been executed yet — the doc is written to be run and its result table filled in by a
  maintainer with dashboard access (marked clearly as pending in the doc)
  
  ### #651 — Consistent validation/error display (Flutter)
  - Audited login, signup, log entry, and settings (change password, security/2FA, profile)
  screens
  - Login, signup, and profile already routed through the shared `ErrorHandler` SnackBar helper —
  left unchanged
  - Replaced raw, inconsistently-styled `ScaffoldMessenger.showSnackBar` calls in
  `create_entry_screen.dart`, `change_password_screen.dart`, and `security_screen.dart` (10+ call
  sites) with `ErrorHandler.showError` / `showSuccess` for one consistent color/style/duration
  pattern app-wide
  - Fixed the 2FA TOTP code field silently doing nothing on an invalid code — now shows an error
  message 
  
  ## Test plan
  - `frontend`: `npm run typecheck` passes (pre-existing, unrelated `ImportRowResult` type errors
  in `logs-import.ts` left untouched — confirmed present on `development` too)
  - `frontend`: relevant vitest suites pass; the handful of failures seen in
  `log-form-page.test.tsx` (mood-button role query mismatch + timeouts) are confirmed
  pre-existing on unmodified `development` via a side-by-side worktree run, not introduced by
  this change
  - Flutter: no toolchain available in this environment to run `flutter analyze`/`flutter test`;
  changes were reviewed manually and existing `security_screen_test.dart` /
  `create_entry_screen_test.dart` don't assert on the SnackBar text/mechanism that changed
  - No new env vars required

  Closes #650, closes #652, closes #649, closes #651

