### PR TITLE
fix(flutter): release Agora engine when a PiP call is torn down without user interaction

### DIFF
--- a/lib/core/services/pip_overlay_service.dart
+++ b/lib/core/services/pip_overlay_service.dart
@@ -1,13 +1,28 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:agora_rtc_engine/agora_rtc_engine.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../themes/app_theme.dart';
 
 /// Service for managing in-app Picture-in-Picture overlay
-class PipOverlayService {
+class PipOverlayService with WidgetsBindingObserver {
   static final PipOverlayService _instance = PipOverlayService._internal();
   factory PipOverlayService() => _instance;
-  PipOverlayService._internal();
+  PipOverlayService._internal() {
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Last-resort safety net: if the app is torn down while a call is
+    // still running in the PiP overlay and the user never tapped the
+    // overlay's close button, release the Agora engine here instead of
+    // leaking the connection (and its paid seat).
+    if (state == AppLifecycleState.detached) {
+      disposeOverlay();
+    }
+  }
 
   OverlayEntry? _overlayEntry;
   bool _isShowing = false;
@@ -83,12 +98,22 @@ class PipOverlayService {
   /// Clean up and dispose the overlay (when ending the call)
   void disposeOverlay() {
     hidePipOverlay();
+    final engine = _engine;
     _engine = null;
     _remoteUid = null;
     _sessionId = null;
     _hostName = null;
     _onTapToExpand = null;
     _onLeaveCall = null;
+
+    if (engine != null) {
+      // Best-effort release — the call's own screen may already have torn
+      // this engine down (e.g. via _leaveCall), so failures here are
+      // expected and safe to ignore.
+      unawaited(
+        engine.leaveChannel().then((_) => engine.release()).catchError((_) {}),
+      );
+    }
   }
 
   /// Update remote video state


### PR DESCRIPTION
PipOverlayService.disposeOverlay() only nulled out its RtcEngine reference — it never called leaveChannel()/release() on the engine itself. The two call sites that DO clean up correctly (VideoCallScreen._leaveCall() and its dispose()) release their own _engine field directly, so this was invisible in the normal flow.

The gap: once a call is handed off to the PiP overlay (_isNavigatingAway = true), VideoCallScreen's own dispose() explicitly skips engine cleanup — by design, since the call is meant to keep running in the floating window. The only cleanup path left is the overlay's close button, which calls disposeOverlay(). If the app process is killed while in PiP (backgrounded and swiped away, or OS memory pressure) before the user ever taps that button, the Agora engine — and its paid seat — was never released.

### What changed
- disposeOverlay() now releases the engine itself (leaveChannel then release), wrapped in a swallowed catchError since the call's own screen may have already torn the same engine down.
- PipOverlayService now observes AppLifecycleState and calls disposeOverlay() on AppLifecycleState.detached as a last-resort safety net, so a killed app releases the engine instead of leaking it.

### Verification
- dart analyze: clean.
- video_call_screen.dart, whose _leaveCall()/dispose() already release their own engine reference before or after calling disposeOverlay(), still analyzes clean — the new release is wrapped in catchError so the pre-existing double-release path is safe.