### PR TITLE
fix(flutter): clear per-user provider state on logout

### DIFF
--- a/lib/features/auth/viewmodel/providers/auth_provider.dart
+++ b/lib/features/auth/viewmodel/providers/auth_provider.dart
@@ -3,6 +3,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../data/models/user_model.dart';
 import '../../data/repositories/auth_repository.dart';
+import '../../../dashboard/viewmodel/providers/dashboard_provider.dart';
+import '../../../dashboard/viewmodel/providers/echo_balance_provider.dart';
+import '../../../dashboard/viewmodel/providers/streak_provider.dart';
+import '../../../dashboard/viewmodel/providers/streak_freeze_provider.dart';
+import '../../../global_mirror/viewmodel/providers/wallet_provider.dart';
+import '../../../global_mirror/viewmodel/providers/gift_provider.dart';
+import '../../../global_mirror/viewmodel/providers/global_mirror_provider.dart';
+import '../../../global_mirror/viewmodel/providers/mood_comment_notification_provider.dart';
+import '../../../logging/viewmodel/providers/logging_provider.dart';
+import '../../../socials/viewmodel/providers/socials_provider.dart';
 
 /// Auth state class
 class AuthState {
@@ -30,11 +40,12 @@ final authRepositoryProvider = Provider<AuthRepository>((ref) {
 
 /// Auth state notifier
 class AuthNotifier extends StateNotifier<AuthState> {
-  AuthNotifier(this._repository) : super(const AuthState()) {
+  AuthNotifier(this._repository, this._ref) : super(const AuthState()) {
     _checkAuthStatus();
   }
 
   final AuthRepository _repository;
+  final Ref _ref;
   bool _isCheckingAuth = false;
 
   /// Check if user is already authenticated
@@ -141,9 +152,25 @@ class AuthNotifier extends StateNotifier<AuthState> {
     try {
       await _repository.signOut();
       state = const AuthState();
+      _invalidateUserScopedProviders();
     } catch (e) {
       state = state.copyWith(isLoading: false, error: e.toString());
     }
+  }
+
+  /// Clears cached per-user state so the next signed-in user never sees
+  /// this account's dashboard, wallet, gifts, streaks, or social data.
+  void _invalidateUserScopedProviders() {
+    _ref.invalidate(dashboardProvider);
+    _ref.invalidate(echoBalanceProvider);
+    _ref.invalidate(streakProvider);
+    _ref.invalidate(streakFreezeProvider);
+    _ref.invalidate(walletProvider);
+    _ref.invalidate(giftProvider);
+    _ref.invalidate(globalMirrorProvider);
+    _ref.invalidate(moodCommentNotificationProvider);
+    _ref.invalidate(loggingProvider);
+    _ref.invalidate(socialsProvider);
   }
 
   /// Request password reset
@@ -222,5 +249,5 @@ class AuthNotifier extends StateNotifier<AuthState> {
 /// Auth provider
 final authProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
   final repository = ref.watch(authRepositoryProvider);
-  return AuthNotifier(repository);
+  return AuthNotifier(repository, ref);
 });

--- a/lib/features/settings/view/screens/security_screen.dart
+++ b/lib/features/settings/view/screens/security_screen.dart
@@ -7,6 +7,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import '../../../../core/themes/app_theme.dart';
+import '../../../auth/viewmodel/providers/auth_provider.dart';
 
 class SecurityScreen extends ConsumerStatefulWidget {
   const SecurityScreen({super.key});
@@ -116,7 +117,7 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
       final client = Supabase.instance.client;
 
       if (sessionId == 'current') {
-        await client.auth.signOut();
+        await ref.read(authProvider.notifier).signOut();
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Signed out successfully')),

--- a/test/features/logging/logging_screen_test.dart
+++ b/test/features/logging/logging_screen_test.dart
@@ -30,15 +30,15 @@ class _FakeLoggingNotifier extends LoggingNotifier {
 }
 
 class _FakeAuthNotifier extends AuthNotifier {
-  _FakeAuthNotifier._(MockAuthRepository repo, AuthState initialState)
-    : super(repo) {
+  _FakeAuthNotifier._(MockAuthRepository repo, Ref ref, AuthState initialState)
+    : super(repo, ref) {
     state = initialState;
   }
 
-  factory _FakeAuthNotifier(AuthState initialState) {
+  factory _FakeAuthNotifier(Ref ref, AuthState initialState) {
     final repo = MockAuthRepository();
     when(() => repo.isAuthenticated()).thenAnswer((_) async => false);
-    return _FakeAuthNotifier._(repo, initialState);
+    return _FakeAuthNotifier._(repo, ref, initialState);
   }
 }
 
@@ -80,7 +80,7 @@ void main() {
         loggingProvider.overrideWith(
           (ref) => _FakeLoggingNotifier(loggingState),
         ),
-        authProvider.overrideWith((ref) => _FakeAuthNotifier(authState)),
+        authProvider.overrideWith((ref) => _FakeAuthNotifier(ref, authState)),
       ],
       child: MaterialApp.router(routerConfig: router),
     );


### PR DESCRIPTION
Riverpod providers in this app never use .autoDispose, so every StateNotifierProvider holding fetched network data (dashboard, wallet, gift, streak, streak freeze, mood comment notifications, logging, global mirror, socials) lives for the process lifetime. AuthNotifier.signOut() only reset its own AuthState — nothing told those other providers the session had ended. If a second user signed in on the same app instance, they'd see the previous user's cached balance, streak, gift history, and comments until each screen's own reload happened to run.

There was also a second sign-out path that bypassed AuthNotifier entirely: SecurityScreen's 'sign out this device' action called Supabase's client.auth.signOut() directly, so AuthState never updated and the app would keep showing the signed-out user's data until the next cold start.

### Fixes
- AuthNotifier now takes a Ref (same pattern as its existing repository dependency) so signOut() can invalidate the per-user providers directly once the session actually ends.
- SecurityScreen's current-device sign-out now goes through ref.read(authProvider.notifier).signOut() instead of calling Supabase directly, so it gets the same cleanup as the main settings sign-out button.

follow_provider.dart's FutureProviders (followingListProvider, friendMoodLogsProvider, etc.) already ref.watch(authProvider) and recompute automatically once AuthState.user goes null — they didn't need explicit invalidation, and importing them into auth_provider.dart would have created a circular import.

### Verification
- dart analyze: clean (the 2 remaining issues, in logging_screen_test.dart and security_screen.dart, are pre-existing — confirmed via git diff against development before this change).